### PR TITLE
enable s3 object key path

### DIFF
--- a/lib/logstash/inputs/s3.rb
+++ b/lib/logstash/inputs/s3.rb
@@ -153,7 +153,7 @@ class LogStash::Inputs::S3 < LogStash::Inputs::Base
 
 
   private
-  def process_local_log(queue, filename)
+  def process_local_log(queue, filename, key)
     @logger.debug('Processing file', :filename => filename)
 
     metadata = {}
@@ -179,7 +179,8 @@ class LogStash::Inputs::S3 < LogStash::Inputs::Base
 
           event["cloudfront_version"] = metadata[:cloudfront_version] unless metadata[:cloudfront_version].nil?
           event["cloudfront_fields"]  = metadata[:cloudfront_fields] unless metadata[:cloudfront_fields].nil?
-
+	  event["path"] = key
+  
           queue << event
         end
       end
@@ -287,7 +288,7 @@ class LogStash::Inputs::S3 < LogStash::Inputs::Base
 
     download_remote_file(object, filename)
 
-    process_local_log(queue, filename)
+    process_local_log(queue, filename, key)
 
     backup_to_bucket(object, key)
     backup_to_dir(filename)

--- a/lib/logstash/inputs/s3.rb
+++ b/lib/logstash/inputs/s3.rb
@@ -179,7 +179,7 @@ class LogStash::Inputs::S3 < LogStash::Inputs::Base
 
           event["cloudfront_version"] = metadata[:cloudfront_version] unless metadata[:cloudfront_version].nil?
           event["cloudfront_fields"]  = metadata[:cloudfront_fields] unless metadata[:cloudfront_fields].nil?
-	  event["path"] = key
+          event["path"] = key
   
           queue << event
         end


### PR DESCRIPTION
I am trying to enable actual S3 object path so that it can be used in filter with grok to match path as we do while using file input.
