### PR TITLE
Fix bug with :aws_credentials_file

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,2 @@
 source 'https://rubygems.org'
 gemspec
-## temp workarround to pass PR 2318, it has to be removed
-## before merging the PR. This is like this because of the updated
-## version of devutils we need to use to run always with rspec3.
-gem "logstash-devutils", ">= 0.0.14", :group => :development, :git => "https://github.com/purbon/logstash-devutils.git", :branch => "feature/upgrade_to_rspec3"

--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,6 @@
 source 'https://rubygems.org'
 gemspec
+## temp workarround to pass PR 2318, it has to be removed
+## before merging the PR. This is like this because of the updated
+## version of devutils we need to use to run always with rspec3.
+gem "logstash-devutils", ">= 0.0.14", :group => :development, :git => "https://github.com/purbon/logstash-devutils.git", :branch => "feature/upgrade_to_rspec3"

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2012-2015 Elasticsearch <http://www.elasticsearch.org>
+Copyright (c) 2012–2015 Elasticsearch <http://www.elastic.co>
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/NOTICE.TXT
+++ b/NOTICE.TXT
@@ -1,0 +1,5 @@
+Elasticsearch
+Copyright 2012-2015 Elasticsearch
+
+This product includes software developed by The Apache Software
+Foundation (http://www.apache.org/).

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Logstash provides infrastructure to automatically generate documentation for thi
 
 ## Need Help?
 
-Need help? Try #logstash on freenode IRC or the logstash-users@googlegroups.com mailing list.
+Need help? Try #logstash on freenode IRC or the https://discuss.elastic.co/c/logstash discussion forum.
 
 ## Developing
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,17 @@ This is a plugin for [Logstash](https://github.com/elasticsearch/logstash).
 
 It is fully free and fully open source. The license is Apache 2.0, meaning you are pretty much free to use it however you want in whatever way.
 
+## Required S3 Permissions
+
+This plugin, as it reads from your S3 bucket, requires the following permissions:
+
+ * `s3:HeadBucket`: This allows the plugin to determine if a bucket exists.
+ * `s3:GetBucket`: This operation lists the objects stored in a bucket.
+ * `s3:HeadObject`: This operation gets metadata on an object in the bucket.
+ * `s3:GetObject`: This operation downloads an object from the bucket.
+
+If you have `:delete` set to `true`, you'll additionally need the `s3:DeleteObject` permission.
+
 ## Documentation
 
 Logstash provides infrastructure to automatically generate documentation for this plugin. We use the asciidoc format to write documentation so any comments in the source code will be first converted into asciidoc and then into html. All plugin documentation are placed under one [central location](http://www.elasticsearch.org/guide/en/logstash/current/).

--- a/lib/logstash/inputs/s3.rb
+++ b/lib/logstash/inputs/s3.rb
@@ -50,6 +50,10 @@ class LogStash::Inputs::S3 < LogStash::Inputs::Base
   # choose a new 'folder' to place the files in
   config :backup_add_prefix, :validate => :string, :default => nil
 
+  # Whether to request serverside encryption for files uploaded by the backup_to_bucket
+  # option.
+  config :backup_to_bucket_encryption, :validate => :boolean, :default => false
+
   # Path of a local directory to backup processed files to.
   config :backup_to_dir, :validate => :string, :default => nil
 
@@ -128,9 +132,9 @@ class LogStash::Inputs::S3 < LogStash::Inputs::Base
     unless @backup_to_bucket.nil?
       backup_key = "#{@backup_add_prefix}#{key}"
       if @delete
-        object.move_to(backup_key, :bucket => @backup_bucket)
+        object.move_to(backup_key, :bucket => @backup_bucket, :server_side_encryption => @backup_to_bucket_encryption ? :aes256 : nil)
       else
-        object.copy_to(backup_key, :bucket => @backup_bucket)
+        object.copy_to(backup_key, :bucket => @backup_bucket, :server_side_encryption => @backup_to_bucket_encryption ? :aes256 : nil)
       end
     end
   end

--- a/lib/logstash/inputs/s3.rb
+++ b/lib/logstash/inputs/s3.rb
@@ -196,7 +196,8 @@ class LogStash::Inputs::S3 < LogStash::Inputs::Base
 
   private
   def event_is_metadata?(event)
-    line = event['message']
+    return false if event["message"].nil?
+    line = event["message"]
     version_metadata?(line) || fields_metadata?(line)
   end
 

--- a/lib/logstash/inputs/s3.rb
+++ b/lib/logstash/inputs/s3.rb
@@ -71,17 +71,17 @@ class LogStash::Inputs::S3 < LogStash::Inputs::Base
     @logger.info("Registering s3 input", :bucket => @bucket, :region => @region)
     @s3 = AWS::S3.new(aws_options_hash)
   end
-
+ 
   public
   def register
     require "fileutils"
     require "digest/md5"
     require "aws-sdk"
-
+    
     # required if using ruby version < 2.0
     # http://ruby.awsblog.com/post/Tx16QY1CI5GVBFT/Threading-with-the-AWS-SDK-for-Ruby
     AWS.eager_autoload!(AWS::S3)
-
+    
     @s3 = aws_s3_config
 
     unless @backup_to_bucket.nil?

--- a/lib/logstash/inputs/s3.rb
+++ b/lib/logstash/inputs/s3.rb
@@ -2,7 +2,6 @@
 require "logstash/inputs/base"
 require "logstash/namespace"
 require "logstash/plugin_mixins/aws_config"
-
 require "time"
 require "tmpdir"
 require "stud/interval"
@@ -75,6 +74,8 @@ class LogStash::Inputs::S3 < LogStash::Inputs::Base
 
   public
   def register
+    require "fileutils"
+    require "digest/md5"
     require "aws-sdk"
 
     # required if using ruby version < 2.0
@@ -93,6 +94,8 @@ class LogStash::Inputs::S3 < LogStash::Inputs::Base
     unless @backup_to_dir.nil?
       Dir.mkdir(@backup_to_dir, 0700) unless File.exists?(@backup_to_dir)
     end
+
+    FileUtils.mkdir_p(@temporary_directory) unless Dir.exist?(@temporary_directory)
   end # def register
 
   public

--- a/lib/logstash/inputs/s3.rb
+++ b/lib/logstash/inputs/s3.rb
@@ -303,6 +303,7 @@ class LogStash::Inputs::S3 < LogStash::Inputs::Base
     backup_to_dir(filename)
 
     delete_file_from_bucket(object)
+    FileUtils.remove_entry_secure(filename, true)
   end
 
   private

--- a/lib/logstash/inputs/s3.rb
+++ b/lib/logstash/inputs/s3.rb
@@ -71,17 +71,17 @@ class LogStash::Inputs::S3 < LogStash::Inputs::Base
     @logger.info("Registering s3 input", :bucket => @bucket, :region => @region)
     @s3 = AWS::S3.new(aws_options_hash)
   end
- 
+
   public
   def register
     require "fileutils"
     require "digest/md5"
     require "aws-sdk"
-    
+
     # required if using ruby version < 2.0
     # http://ruby.awsblog.com/post/Tx16QY1CI5GVBFT/Threading-with-the-AWS-SDK-for-Ruby
     AWS.eager_autoload!(AWS::S3)
-    
+
     @s3 = aws_s3_config
 
     unless @backup_to_bucket.nil?

--- a/logstash-input-s3.gemspec
+++ b/logstash-input-s3.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-s3'
-  s.version         = '0.1.9'
+  s.version         = '0.1.10'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Stream events from files from a S3 bucket."
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"

--- a/logstash-input-s3.gemspec
+++ b/logstash-input-s3.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-s3'
-  s.version         = '0.1.11'
+  s.version         = '1.0.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Stream events from files from a S3 bucket."
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"

--- a/logstash-input-s3.gemspec
+++ b/logstash-input-s3.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-s3'
-  s.version         = '0.1.10'
+  s.version         = '0.1.11'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Stream events from files from a S3 bucket."
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"

--- a/logstash-input-s3.gemspec
+++ b/logstash-input-s3.gemspec
@@ -5,9 +5,9 @@ Gem::Specification.new do |s|
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Stream events from files from a S3 bucket."
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"
-  s.authors         = ["Elasticsearch"]
-  s.email           = 'info@elasticsearch.com'
-  s.homepage        = "http://www.elasticsearch.org/guide/en/logstash/current/index.html"
+  s.authors         = ["Elastic"]
+  s.email           = 'info@elastic.co'
+  s.homepage        = "http://www.elastic.co/guide/en/logstash/current/index.html"
   s.require_paths = ["lib"]
 
   # Files

--- a/logstash-input-s3.gemspec
+++ b/logstash-input-s3.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-s3'
-  s.version         = '0.1.8'
+  s.version         = '0.1.9'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Stream events from files from a S3 bucket."
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"

--- a/logstash-input-s3.gemspec
+++ b/logstash-input-s3.gemspec
@@ -27,5 +27,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'logstash-devutils'
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'coveralls'
+  s.add_development_dependency "logstash-codec-json"
 end
 

--- a/spec/fixtures/json.log
+++ b/spec/fixtures/json.log
@@ -1,0 +1,2 @@
+{ "hello": "world" }
+{ "hello": "awesome world" }

--- a/spec/inputs/s3_spec.rb
+++ b/spec/inputs/s3_spec.rb
@@ -166,7 +166,7 @@ describe LogStash::Inputs::S3 do
 
           config.backup_to_dir(source_file)
 
-          expect(File.exists?(backup_file)).to be_true
+          expect(File.exists?(backup_file)).to eq(true)
         end
       end
     end

--- a/spec/inputs/s3_spec.rb
+++ b/spec/inputs/s3_spec.rb
@@ -207,6 +207,20 @@ describe LogStash::Inputs::S3 do
       expect(log).to receive(:read)  { |&block| block.call(File.read(log_file)) }
     end
 
+    context "when event doesn't have a `message` field" do
+      let(:log_file) { File.join(File.dirname(__FILE__), '..', 'fixtures', 'json.log') }
+      let(:settings) {
+        {
+          "access_key_id" => "1234",
+          "secret_access_key" => "secret",
+          "bucket" => "logstash-test",
+          "codec" => "json",
+        }
+      }
+
+      include_examples "generated events"
+    end
+
     context 'compressed' do
       let(:log) { double(:key => 'log.gz', :last_modified => Time.now - 2 * day) }
       let(:log_file) { File.join(File.dirname(__FILE__), '..', 'fixtures', 'compressed.log.gz') }

--- a/spec/inputs/s3_spec.rb
+++ b/spec/inputs/s3_spec.rb
@@ -20,6 +20,27 @@ describe LogStash::Inputs::S3 do
     }
   }
 
+  describe "#register" do
+    subject { LogStash::Inputs::S3.new(settings) }
+
+    context "with temporary directory" do
+      let(:settings) {
+        {
+          "access_key_id" => "1234",
+          "secret_access_key" => "secret",
+          "bucket" => "logstash-test",
+          "temporary_directory" => temporary_directory
+        }
+      }
+
+      let(:temporary_directory) { Stud::Temporary.pathname }
+
+      it "creates the direct when it doesn't exist" do
+        expect { subject.register }.to change { Dir.exist?(temporary_directory) }.from(false).to(true)
+      end
+    end
+  end
+
   describe "#list_new_files" do
     before { allow_any_instance_of(AWS::S3::ObjectCollection).to receive(:with_prefix).with(nil) { objects_list } }
 


### PR DESCRIPTION
This plugin is lagging  behind the S3 output plugin and the :aws_credentials_file parameter doesn't work here. I've gone through, optimized the source code, and had it use the AWS mixin's handling of parsing AWS credentials. 