### PR TITLE
Make sure the temporary directory exist before downloading the files

### DIFF
--- a/lib/logstash/inputs/s3.rb
+++ b/lib/logstash/inputs/s3.rb
@@ -2,7 +2,6 @@
 require "logstash/inputs/base"
 require "logstash/namespace"
 require "logstash/plugin_mixins/aws_config"
-
 require "time"
 require "tmpdir"
 require "stud/interval"
@@ -70,6 +69,7 @@ class LogStash::Inputs::S3 < LogStash::Inputs::Base
 
   public
   def register
+    require "fileutils"
     require "digest/md5"
     require "aws-sdk"
 
@@ -91,6 +91,8 @@ class LogStash::Inputs::S3 < LogStash::Inputs::Base
     unless @backup_to_dir.nil?
       Dir.mkdir(@backup_to_dir, 0700) unless File.exists?(@backup_to_dir)
     end
+
+    FileUtils.mkdir_p(@temporary_directory) unless Dir.exist?(@temporary_directory)
   end # def register
 
   public

--- a/spec/inputs/s3_spec.rb
+++ b/spec/inputs/s3_spec.rb
@@ -20,6 +20,27 @@ describe LogStash::Inputs::S3 do
     }
   }
 
+  describe "#register" do
+    subject { LogStash::Inputs::S3.new(settings) }
+
+    context "with temporary directory" do
+      let(:settings) {
+        {
+          "access_key_id" => "1234",
+          "secret_access_key" => "secret",
+          "bucket" => "logstash-test",
+          "temporary_directory" => temporary_directory
+        }
+      }
+
+      let(:temporary_directory) { Stud::Temporary.pathname }
+
+      it "creates the direct when it doesn't exist" do
+        expect { subject.register }.to change { Dir.exist?(temporary_directory) }.from(false).to(true)
+      end
+    end
+  end
+
   describe "#list_new_files" do
     before { allow_any_instance_of(AWS::S3::ObjectCollection).to receive(:with_prefix).with(nil) { objects_list } }
 


### PR DESCRIPTION
Logstash crash when downloading files if the `temporary_directory` doesn't exist, this PR make sure the directory exist before any downloading is done.

Fixes https://github.com/logstash-plugins/logstash-input-s3/issues/32