### PR TITLE
Add a check if the `message` field exist

### DIFF
--- a/lib/logstash/inputs/s3.rb
+++ b/lib/logstash/inputs/s3.rb
@@ -190,7 +190,8 @@ class LogStash::Inputs::S3 < LogStash::Inputs::Base
 
   private
   def event_is_metadata?(event)
-    line = event['message']
+    return false if event["message"].nil?
+    line = event["message"]
     version_metadata?(line) || fields_metadata?(line)
   end
 

--- a/logstash-input-s3.gemspec
+++ b/logstash-input-s3.gemspec
@@ -27,5 +27,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'logstash-devutils'
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'coveralls'
+  s.add_development_dependency "logstash-codec-json"
 end
 

--- a/spec/fixtures/json.log
+++ b/spec/fixtures/json.log
@@ -1,0 +1,2 @@
+{ "hello": "world" }
+{ "hello": "awesome world" }

--- a/spec/inputs/s3_spec.rb
+++ b/spec/inputs/s3_spec.rb
@@ -207,6 +207,20 @@ describe LogStash::Inputs::S3 do
       expect(log).to receive(:read)  { |&block| block.call(File.read(log_file)) }
     end
 
+    context "when event doesn't have a `message` field" do
+      let(:log_file) { File.join(File.dirname(__FILE__), '..', 'fixtures', 'json.log') }
+      let(:settings) {
+        {
+          "access_key_id" => "1234",
+          "secret_access_key" => "secret",
+          "bucket" => "logstash-test",
+          "codec" => "json",
+        }
+      }
+
+      include_examples "generated events"
+    end
+
     context 'compressed' do
       let(:log) { double(:key => 'log.gz', :last_modified => Time.now - 2 * day) }
       let(:log_file) { File.join(File.dirname(__FILE__), '..', 'fixtures', 'compressed.log.gz') }


### PR DESCRIPTION
If the event was missing a `message` field the plugin would crash, this PR add a check to make
sure the key exist before trying to extract the metadata.

Fixes #27