### PR TITLE
Fix s3 input for aws mixin

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,24 @@ This is a plugin for [Logstash](https://github.com/elasticsearch/logstash).
 
 It is fully free and fully open source. The license is Apache 2.0, meaning you are pretty much free to use it however you want in whatever way.
 
+## Required S3 Permissions
+
+This plugin reads from your S3 bucket, and would require the following
+permissions applied to the AWS IAM Policy being used:
+
+* `s3:ListBucket` to check if the S3 bucket exists and list objects in it.
+* `s3:GetObject` to check object metadata and download objects from S3 buckets.
+
+You might also need `s3:DeleteObject` when setting S3 input to delete on read.
+And the `s3:CreateBucket` permission to create a backup bucket unless already
+exists.
+
+For buckets that have versioning enabled, you might need to add additional
+permissions.
+
+More information about S3 permissions can be found at -
+  http://docs.aws.amazon.com/AmazonS3/latest/dev/using-with-s3-actions.html
+
 ## Documentation
 
 Logstash provides infrastructure to automatically generate documentation for this plugin. We use the asciidoc format to write documentation so any comments in the source code will be first converted into asciidoc and then into html. All plugin documentation are placed under one [central location](http://www.elasticsearch.org/guide/en/logstash/current/).

--- a/lib/logstash/inputs/s3.rb
+++ b/lib/logstash/inputs/s3.rb
@@ -77,8 +77,11 @@ class LogStash::Inputs::S3 < LogStash::Inputs::Base
 
     @logger.info("Registering s3 input", :bucket => @bucket, :region => @region)
 
-    s3 = get_s3object
+    # required for ruby version < 2.0
+    # http://ruby.awsblog.com/post/Tx16QY1CI5GVBFT/Threading-with-the-AWS-SDK-for-Ruby
+    AWS.eager_autoload!(AWS::S3)
 
+    s3 = get_s3object
     @s3bucket = s3.buckets[@bucket]
 
     unless @backup_to_bucket.nil?
@@ -350,7 +353,7 @@ class LogStash::Inputs::S3 < LogStash::Inputs::Base
       @secret_access_key = @credentials[1]
     end
 
-    if @credentials
+    if !@credentials.empty?
       s3 = AWS::S3.new(
         :access_key_id => @access_key_id,
         :secret_access_key => @secret_access_key,
@@ -361,7 +364,7 @@ class LogStash::Inputs::S3 < LogStash::Inputs::Base
     end
   end
 
-  private
+  public
   def aws_service_endpoint(region)
     return { :s3_endpoint => region }
   end


### PR DESCRIPTION
The S3 input plugin was half-updated to use the new AWS Mixin. Having deprecated `@credentials` checked in a condition for falsiness when its default is an empty Array failed. And when that is fixed, the `aws_service_endpoint` being called by the mixin should be public and not private.