### PR TITLE
Fix Proxy Support

### DIFF
--- a/lib/logstash/inputs/s3.rb
+++ b/lib/logstash/inputs/s3.rb
@@ -153,6 +153,10 @@ class LogStash::Inputs::S3 < LogStash::Inputs::Base
     end
   end # def process_files
 
+  public
+  def aws_service_endpoint(region)
+    return { :s3_endpoint => region }
+  end
 
   private
   def process_local_log(queue, filename)
@@ -350,22 +354,10 @@ class LogStash::Inputs::S3 < LogStash::Inputs::Base
       @secret_access_key = @credentials[1]
     end
 
-    if @credentials
-      s3 = AWS::S3.new(
-        :access_key_id => @access_key_id,
-        :secret_access_key => @secret_access_key,
-        :region => @region
-      )
-    else
-      s3 = AWS::S3.new(aws_options_hash)
-    end
+    s3 = AWS::S3.new(aws_options_hash)
   end
 
   private
-  def aws_service_endpoint(region)
-    return { :s3_endpoint => region }
-  end
-
   module SinceDB
     class File
       def initialize(file)

--- a/lib/logstash/inputs/s3.rb
+++ b/lib/logstash/inputs/s3.rb
@@ -155,7 +155,12 @@ class LogStash::Inputs::S3 < LogStash::Inputs::Base
 
   public
   def aws_service_endpoint(region)
-    return { :s3_endpoint => region }
+    region_to_use = get_region
+
+    return {
+      :s3_endpoint => region_to_use == 'us-east-1' ?
+        's3.amazonaws.com' : "s3-#{region_to_use}.amazonaws.com"
+    }
   end
 
   private

--- a/spec/inputs/s3_spec.rb
+++ b/spec/inputs/s3_spec.rb
@@ -63,8 +63,7 @@ describe LogStash::Inputs::S3 do
           :secret_access_key => "secret",
           :proxy_uri => 'http://example.com',
           :use_ssl => subject.use_ssl,
-          :s3_endpoint => subject.region,
-        })
+        }.merge(subject.aws_service_endpoint(subject.region)))
 
         subject.send(:get_s3object)
       end
@@ -86,8 +85,8 @@ describe LogStash::Inputs::S3 do
           :secret_access_key => "secret",
           :proxy_uri => 'http://example.com',
           :use_ssl => subject.use_ssl,
-          :s3_endpoint => subject.region,
-        })
+        }.merge(subject.aws_service_endpoint(subject.region)))
+        
 
         subject.send(:get_s3object)
       end

--- a/spec/inputs/s3_spec.rb
+++ b/spec/inputs/s3_spec.rb
@@ -45,6 +45,55 @@ describe LogStash::Inputs::S3 do
     end
   end
 
+  describe '#get_s3object' do
+    subject { LogStash::Inputs::S3.new(settings) }
+
+    context 'with deprecated credentials option' do
+      let(:settings) {
+        {
+          "credentials" => ["1234", "secret"],
+          "proxy_uri" => "http://example.com",
+          "bucket" => "logstash-test",
+        }
+      }
+
+      it 'should instantiate AWS::S3 clients with a proxy set' do
+        expect(AWS::S3).to receive(:new).with({
+          :access_key_id => "1234",
+          :secret_access_key => "secret",
+          :proxy_uri => 'http://example.com',
+          :use_ssl => subject.use_ssl,
+          :s3_endpoint => subject.region,
+        })
+
+        subject.send(:get_s3object)
+      end
+    end
+
+    context 'with modern access key options' do
+      let(:settings) {
+        {
+          "access_key_id" => "1234",
+          "secret_access_key" => "secret",
+          "proxy_uri" => "http://example.com",
+          "bucket" => "logstash-test",
+        }
+      }
+
+      it 'should instantiate AWS::S3 clients with a proxy set' do
+        expect(AWS::S3).to receive(:new).with({
+          :access_key_id => "1234",
+          :secret_access_key => "secret",
+          :proxy_uri => 'http://example.com',
+          :use_ssl => subject.use_ssl,
+          :s3_endpoint => subject.region,
+        })
+
+        subject.send(:get_s3object)
+      end
+    end
+  end
+
   describe "#list_new_files" do
     before { allow_any_instance_of(AWS::S3::ObjectCollection).to receive(:with_prefix).with(nil) { objects_list } }
 


### PR DESCRIPTION
Earlier this week, in IRC, it was determined that proxy support is not functional for this plugin, for a few reasons. This PR seeks to resolve those.

Firstly, as is pointed out in #46, the ```if @credentials``` check always returned true, as that variable defaults to ```[]```. My solution to that was to rely on aws_options_hash to normalize the configuration, regardless of the Logstash config keys in use.

This fix uncovered another problem - namely that the ```aws_service_endpoint``` method was originally private in this plugin. Now that it is actually getting called by the AwsConfig mixin, this needs to be reconciled. After checking the s3 output, I decided to follow that plugin's lead, and mark this method as public.

Finally, it was revealed that ```aws_service_endpoint``` did not yield a value appropriate for use with the upstream class, so for good measure, the functionality of this method was copied over from the s3 output.