### PR TITLE
Refactor the shutdown sequence of this plugin to follow the new semantic

### DIFF
--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -3,7 +3,6 @@ def fetch_events(settings)
   s3 = LogStash::Inputs::S3.new(settings)
   s3.register
   s3.process_files(queue)
-  s3.close
   queue
 end
 
@@ -32,3 +31,15 @@ end
 def s3object
   AWS::S3.new
 end
+
+class TestInfiniteS3Object
+  def each
+    counter = 1
+
+    loop do
+      yield "awesome-#{counter}"
+      counter +=1
+    end
+  end
+end
+


### PR DESCRIPTION
This plugin is now interruptable, this plugin require a bit more care to
shutdown it down for a few reasons:

1. It can be stuck streaming file to disk from a S3 bucket.
2. It can be stuck reading a large file

For case 1, we cancel the streaming and delete the incomplete temp file
and not update the sincedb.

For case 2, we will cancel reading the file and not update the sincedb,
this will result in duplicates in the logging stream which is fine for now since the S3 plugin
doesn't support saving offset yet. see #54

This PR also add a fix to non deterministic test run in a local
environment by specifying a new sincedb for each run.

Fixes: #53 #42