### PR TITLE
Fix for Error: No Such Key problem when delete (with or without backu…

### DIFF
--- a/lib/logstash/inputs/s3.rb
+++ b/lib/logstash/inputs/s3.rb
@@ -320,11 +320,11 @@ class LogStash::Inputs::S3 < LogStash::Inputs::Base
     
     if download_remote_file(object, filename)
       if process_local_log(queue, filename)
+        lastmod = object.last_modified
         backup_to_bucket(object, key)
         backup_to_dir(filename)
         delete_file_from_bucket(object)
         FileUtils.remove_entry_secure(filename, true)
-        lastmod = object.last_modified
         sincedb.write(lastmod)
       end
     else


### PR DESCRIPTION
When delete is set to true, the input plugin will read the entire set of files in the S3 bucket, then process in the oldest file and then crashes with the following error:

```
A plugin had an unrecoverable error. Will restart this plugin.
  Plugin: <LogStash::Inputs::S3 type=>"elb", bucket=>"elb-test-log-processing", region=>"ap-southeast-2", sincedb_path=>"/data/app/logstash-2.0.0/.sincedb", interval=>10, backup_to_bucket=>"elb_test_backup", delete=>true, codec=><LogStash::Codecs::Plain charset=>"UTF-8">, use_ssl=>true, temporary_directory=>"/tmp/logstash">                                                                                
  Error: No Such Key {:level=>:error}
```

This is caused by the S3 object no longer existing in the original bucket when calling for the last modified date. This patch ensures that the last modified date is requested before the object is deleted but is not written to the sincedb file until the operations are complete.

If you would like me to write a test for this condition using ordered expectations, please let me know. I am wary of introducing them though because they will make the specs brittle and future changes will be harder.