### PR TITLE
Skip zero-byte S3 objects

### DIFF
--- a/lib/logstash/inputs/s3.rb
+++ b/lib/logstash/inputs/s3.rb
@@ -111,7 +111,7 @@ class LogStash::Inputs::S3 < LogStash::Inputs::Base
       @logger.debug("S3 input: Found key", :key => log.key)
 
       unless ignore_filename?(log.key)
-        if sincedb.newer?(log.last_modified)
+        if sincedb.newer?(log.last_modified) && log.content_size > 0
           objects[log.key] = log.last_modified
           @logger.debug("S3 input: Adding to objects[]", :key => log.key)
         end


### PR DESCRIPTION
Fix #2.

Hi, I'm the one originally reported the issue. The issue still remains in master and it would be appreciated if you could merge this patch into the mainline.
