### PR TITLE
Check that s3 object exists before trying to get its attributes

### DIFF
--- a/lib/logstash/inputs/s3.rb
+++ b/lib/logstash/inputs/s3.rb
@@ -111,7 +111,7 @@ class LogStash::Inputs::S3 < LogStash::Inputs::Base
       @logger.debug("S3 input: Found key", :key => log.key)
 
       unless ignore_filename?(log.key)
-        if sincedb.newer?(log.last_modified)
+        if log.exists? && sincedb.newer?(log.last_modified)
           objects[log.key] = log.last_modified
           @logger.debug("S3 input: Adding to objects[]", :key => log.key)
         end


### PR DESCRIPTION
Hi.

I had an error when working with bucket w/ versioning enabled. Some "s3 objects" that returned didn't really exist, So I added this expression to the if clause before trying to get its attributes (`log.last_modified` actually throwed s3 key does not exists).

I'm not sure what caused it, Because AWS SDK shouldn't return "deleted" objects from versioned buckets unless you explicitly ask for it. 
