### PR TITLE
Bug Fix: When used with the multiline codec, the last event may be missed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ coverage/
 .idea/*
 .ruby-version
 .github/
+.gradle/
+.rakeTasks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.1.7
+  - Fix missing last multi-line entry #120
+
 ## 3.1.6
   - Fix some documentation issues
 

--- a/lib/logstash/inputs/s3.rb
+++ b/lib/logstash/inputs/s3.rb
@@ -196,6 +196,10 @@ class LogStash::Inputs::S3 < LogStash::Inputs::Base
         end
       end
     end
+    # #ensure any stateful codecs (such as multi-line ) are flushed to the queue
+    @codec.flush do |event|
+      queue << event
+    end
 
     return true
   end # def process_local_log

--- a/logstash-input-s3.gemspec
+++ b/logstash-input-s3.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-s3'
-  s.version         = '3.1.6'
+  s.version         = '3.1.7'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Stream events from files from a S3 bucket."
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -26,5 +26,5 @@ Gem::Specification.new do |s|
  # s.add_runtime_dependency 'aws-sdk-resources', '>= 2.0.33'
   s.add_development_dependency 'logstash-devutils'
   s.add_development_dependency "logstash-codec-json"
+  s.add_development_dependency "logstash-codec-multiline"
 end
-

--- a/spec/fixtures/multiline.log
+++ b/spec/fixtures/multiline.log
@@ -1,0 +1,6 @@
+__SEPARATOR__
+file:1 record:1 line:1
+file:1 record:1 line:2
+__SEPARATOR__
+file:1 record:2 line:1
+file:1 record:2 line:2

--- a/spec/inputs/s3_spec.rb
+++ b/spec/inputs/s3_spec.rb
@@ -1,6 +1,7 @@
 # encoding: utf-8
 require "logstash/devutils/rspec/spec_helper"
 require "logstash/inputs/s3"
+require "logstash/codecs/multiline"
 require "logstash/errors"
 require "aws-sdk-resources"
 require_relative "../support/helpers"
@@ -286,6 +287,20 @@ describe LogStash::Inputs::S3 do
 
     context 'plain text' do
       let(:log_file) { File.join(File.dirname(__FILE__), '..', 'fixtures', 'uncompressed.log') }
+
+      include_examples "generated events"
+    end
+
+    context 'multi-line' do
+      let(:log_file) { File.join(File.dirname(__FILE__), '..', 'fixtures', 'multiline.log') }
+       let(:config) {
+           {
+              "access_key_id" => "1234",
+              "secret_access_key" => "secret",
+              "bucket" => "logstash-test",
+              "codec" => LogStash::Codecs::Multiline.new( {"pattern" => "__SEPARATOR__", "negate" => "true",  "what" => "previous"})
+           }
+        }
 
       include_examples "generated events"
     end


### PR DESCRIPTION

This fix is to simply flush the codec buffer after the end each file.
Note - Due to the way this plugin operates, the auto_flush is a no-op, but as of this change, the flush will happen at the end of every file pulled from S3.

Fixes #120
