### PR TITLE
Use path.data for storing s3 sincedb.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 ## 3.1.9
   - Change default sincedb path to live in `{path.data}/plugins/inputs/s3` instead of $HOME.
-    Upgrades should not be negatively impacted because the old file in $HOME should be detected
-    and migrated to the new default location automatically.
+    Prior Logstash installations (using $HOME default) are automatically migrated.
 
 ## 3.1.8
   - Update gemspec summary

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.1.9
+  - Change default sincedb path to live in `{path.data}/plugins/inputs/s3` instead of $HOME.
+    Upgrades should not be negatively impacted because the old file in $HOME should be detected
+    and migrated to the new default location automatically.
+
 ## 3.1.8
   - Update gemspec summary
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -196,8 +196,9 @@ The AWS Session token for temporary credential
 
 Where to write the since database (keeps track of the date
 the last handled file was added to S3). The default will write
-sincedb files to some path matching "$HOME/.sincedb*"
-Should be a path with filename not just a directory.
+sincedb files to in the directory '{path.data}/plugins/inputs/s3/'
+
+If specified, this setting must be a filename path and not just a directory.
 
 [id="plugins-{type}s-{plugin}-temporary_directory"]
 ===== `temporary_directory` 

--- a/lib/logstash/inputs/s3.rb
+++ b/lib/logstash/inputs/s3.rb
@@ -295,6 +295,9 @@ class LogStash::Inputs::S3 < LogStash::Inputs::Base
 
     # Migrate old default sincedb path to new one.
     if ENV["HOME"]
+      # This is the old file path including the old digest mechanism.
+      # It remains as a way to automatically upgrade users with the old default ($HOME)
+      # to the new default (path.data)
       old = File.join(ENV["HOME"], ".sincedb_" + Digest::MD5.hexdigest("#{@bucket}+#{@prefix}"))
       if File.exist?(old)
         logger.info("Migrating old sincedb in $HOME to {path.data}")

--- a/logstash-input-s3.gemspec
+++ b/logstash-input-s3.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.metadata = { "logstash_plugin" => "true", "logstash_group" => "input" }
 
   # Gem dependencies
-  s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
+  s.add_runtime_dependency "logstash-core-plugin-api", ">= 2.1.16", "<= 2.99"
   s.add_runtime_dependency 'logstash-mixin-aws'
   s.add_runtime_dependency 'stud', '~> 0.0.18'
  # s.add_runtime_dependency 'aws-sdk-resources', '>= 2.0.33'

--- a/logstash-input-s3.gemspec
+++ b/logstash-input-s3.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-s3'
-  s.version         = '3.1.8'
+  s.version         = '3.1.9'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Streams events from files in a S3 bucket"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Use path.data for storing s3 sincedb.

This solves #93, sorta, by no longer needing $HOME.

Added automatic migration code that checks if there's an old
$HOME/.sincedb-... file and moves it automatically to the new default
location.

Thanks to Emily Gladstone Cole who helped me rediscover this bug tonight
