### PR TITLE
gzip: add config for reading whole gzip chunks ("speed"-mode)

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -49,6 +49,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-session_token>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-sincedb_path>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-temporary_directory>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-gzip_prefer>> |<<string,string>>, one of `["memory","speed"]`|No
 |=======================================================================
 
 Also see <<plugins-{type}s-{plugin}-common-options>> for a list of options supported by all
@@ -209,6 +210,15 @@ If specified, this setting must be a filename path and not just a directory.
 Set the directory where logstash will store the tmp files before processing them.
 default to the current OS temporary directory in linux /tmp/logstash
 
+[id="plugins-{type}s-{plugin}-gzip_prefer"]
+===== `gzip_prefer`
+
+  * Value type is <<string,string>>, one of `["memory","speed"]`
+  * Default value is `"memory"`
+
+If processing gzip files, prefer either a stable memory profile or all-out speed.
+This configuration is to be used with caution, as selecting `speed` comes at the cost of
+unpredictable memory consumption, as each gzip chunk is spooled into memory and processed whole.
 
 
 [id="plugins-{type}s-{plugin}-common-options"]

--- a/spec/inputs/s3_spec.rb
+++ b/spec/inputs/s3_spec.rb
@@ -285,6 +285,17 @@ describe LogStash::Inputs::S3 do
       include_examples "generated events"
     end
 
+    context 'compressed in speed mode' do
+      let(:config) do
+        super().merge('gzip_optimise' => 'speed')
+      end
+
+      let(:log) { double(:key => 'log.gz', :last_modified => Time.now - 2 * day, :content_length => 5) }
+      let(:log_file) { File.join(File.dirname(__FILE__), '..', 'fixtures', 'compressed.log.gz') }
+
+      include_examples "generated events"
+    end
+
     context 'plain text' do
       let(:log_file) { File.join(File.dirname(__FILE__), '..', 'fixtures', 'uncompressed.log') }
 


### PR DESCRIPTION
Ruby's `Zlib::GZipReader#each_line` is notoriously slow, so while it is capable of maintaining a steady memory profile by "streaming" one line at a time, in practice the overhead is painful.

As a stop-gap measure, this PR intoduces a new config parameter `gzip_prefer`, whose default value is `memory`, but can be set to `speed`.

 - When `memory` is selected, it behaves as it always has: each decoded line is yielded by `Zlib::GzipReader#each_line`.
 - When `speed` is selected, each gzip chunk is read entirely into a single string with `Zlib::GZipReader#read`, and _then_ yielded line-by-line with `String#each_line`; this routes around the problem of `Zlib::GzipReader#each_line` at the cost of the predictability of memory consumption.

This should alleviate the pain of the following tickets:
 - https://github.com/logstash-plugins/logstash-input-s3/issues/124
 - https://github.com/logstash-plugins/logstash-input-s3/issues/78

Ideally, we could be using a combination of `java.util.zip.GZipInputStream` and `java.io.BufferedReader` to do the bulk of the work on that Java-side of JRuby, but that work would present more risk and require more extensive testing.