### PR TITLE
Swallow an exception on log processing

### DIFF
--- a/lib/logstash/inputs/s3.rb
+++ b/lib/logstash/inputs/s3.rb
@@ -246,11 +246,14 @@ class LogStash::Inputs::S3 < LogStash::Inputs::Base
 
   private
   def read_file(filename, &block)
-    if gzip?(filename) 
+    if gzip?(filename)
       read_gzip_file(filename, block)
     else
       read_plain_file(filename, block)
     end
+  rescue => e
+    # skip any broken file
+    @logger.error("Failed to read the file. Skip processing.", :filename => filename, :exception => e.message)
   end
 
   def read_plain_file(filename, block)
@@ -269,9 +272,6 @@ class LogStash::Inputs::S3 < LogStash::Inputs::Base
     while (line = buffered.readLine())
       block.call(line)
     end
-  rescue ZipException => e
-    @logger.error("Gzip codec: We cannot uncompress the gzip file", :filename => filename)
-    raise e
   ensure
     buffered.close unless buffered.nil?
     decoder.close unless decoder.nil?


### PR DESCRIPTION
This commit replaces @shuwada's [commit](https://github.com/logstash-plugins/logstash-input-s3/pull/70/commits/3f1e750ffbe2b0d51ed5517f4b5a691c4b4e7b89) ([PR#70](https://github.com/logstash-plugins/logstash-input-s3/pull/70)) that was created ~3 years ago

The plugin should't crash if a bad file was uploaded to S3.

Should fix https://github.com/logstash-plugins/logstash-input-s3/issues/135 and https://github.com/logstash-plugins/logstash-input-s3/issues/31