### PR TITLE
add support for force_path_style option

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -41,6 +41,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-bucket>> |<<string,string>>|Yes
 | <<plugins-{type}s-{plugin}-delete>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-exclude_pattern>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-force_path_style>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-interval>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-prefix>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-proxy_uri>> |<<string,string>>|No
@@ -138,6 +139,15 @@ Whether to delete processed files from the original bucket.
   * Default value is `nil`
 
 Ruby style regexp of keys to exclude from the bucket
+
+[id="plugins-{type}s-{plugin}-force_path_style"]
+===== `force_path_style`
+
+  * Value type is <<boolean,boolean>>
+  * Default value is `false`
+
+When set to `true`, the bucket name is always left in the request URI and
+never moved to the host as a sub-domain.
 
 [id="plugins-{type}s-{plugin}-interval"]
 ===== `interval` 

--- a/lib/logstash/inputs/s3.rb
+++ b/lib/logstash/inputs/s3.rb
@@ -35,6 +35,10 @@ class LogStash::Inputs::S3 < LogStash::Inputs::Base
   # If specified, the prefix of filenames in the bucket must match (not a regexp)
   config :prefix, :validate => :string, :default => nil
 
+  # When set to true, the bucket name is always left in the request URI and
+  # never moved to the host as a sub-domain.
+  config :force_path_style, :validate => :boolean, :default => false
+
   # The path to use for writing state. The state stored by this plugin is
   # a memory of files already processed by this plugin.
   #
@@ -386,7 +390,12 @@ class LogStash::Inputs::S3 < LogStash::Inputs::Base
 
   private
   def get_s3object
-    s3 = Aws::S3::Resource.new(aws_options_hash)
+    options = aws_options_hash || {}
+    if @force_path_style == true
+      options.merge!(:force_path_style => @force_path_style)
+    end
+
+    s3 = Aws::S3::Resource.new(options)
   end
 
   private

--- a/spec/inputs/s3_spec.rb
+++ b/spec/inputs/s3_spec.rb
@@ -76,6 +76,24 @@ describe LogStash::Inputs::S3 do
         subject.send(:get_s3object)
       end
     end
+
+    context 'when force_path_style is set' do
+      let(:settings) {
+        {
+          "force_path_style" => true,
+          "bucket" => "logstash-test",
+        }
+      }
+
+      it 'should instantiate AWS::S3 clients with force_path_style set' do
+        expect(Aws::S3::Resource).to receive(:new).with({
+          :region => subject.region,
+          :force_path_style => true
+        })
+
+        subject.send(:get_s3object)
+      end
+    end
   end
 
   describe "#list_new_files" do


### PR DESCRIPTION
this is useful when using custom endpoints in s3

replaces https://github.com/logstash-plugins/logstash-input-s3/pull/139