### PR TITLE
Improve error handling when listing/downloading from S3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.3.1
+ - Improve error handling when listing/downloading from S3 #144
+
 ## 3.3.0
   - Add documentation for endpoint, role_arn and role_session_name #142
   - Add support for additional_settings option #141

--- a/logstash-input-s3.gemspec
+++ b/logstash-input-s3.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-s3'
-  s.version         = '3.3.0'
+  s.version         = '3.3.1'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Streams events from files in a S3 bucket"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Add error checking to:
  Stop plugin from crashing when S3 service errors occur when listing
    the contents of buckets, or downloading files.
  Add log messages when buckets cannot be list/files cannot be downloaded

The error checking should allow the plugin to recover if the error conditions
occur while not blocking progress of handling other items.

This should fix/improve the experience with #143, #133 and #59


