### PR TITLE
Symbolize additional_settings hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.3.3
+  - Symbolize hash keys for additional_settings hash #148
+
 ## 3.3.2
   - Docs: Set the default_codec doc attribute.
 

--- a/lib/logstash/inputs/s3.rb
+++ b/lib/logstash/inputs/s3.rb
@@ -323,6 +323,16 @@ class LogStash::Inputs::S3 < LogStash::Inputs::Base
     path
   end
 
+  def symbolized_settings
+    @symbolized_settings ||= symbolize(@additional_settings)
+  end
+
+  def symbolize(hash)
+    return hash unless hash.is_a?(Hash)
+    symbolized = {}
+    hash.each { |key, value| symbolized[key.to_sym] = symbolize(value) }
+    symbolized
+  end
 
   private
   def old_sincedb_file
@@ -394,7 +404,7 @@ class LogStash::Inputs::S3 < LogStash::Inputs::Base
 
   private
   def get_s3object
-    options = @additional_settings.merge(aws_options_hash || {})
+    options = symbolized_settings.merge(aws_options_hash || {})
     s3 = Aws::S3::Resource.new(options)
   end
 

--- a/logstash-input-s3.gemspec
+++ b/logstash-input-s3.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-s3'
-  s.version         = '3.3.2'
+  s.version         = '3.3.3'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Streams events from files in a S3 bucket"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/inputs/s3_spec.rb
+++ b/spec/inputs/s3_spec.rb
@@ -89,7 +89,7 @@ describe LogStash::Inputs::S3 do
         it 'should instantiate AWS::S3 clients with force_path_style set' do
           expect(Aws::S3::Resource).to receive(:new).with({
             :region => subject.region,
-            "force_path_style" => true
+            :force_path_style => true
           }).and_call_original
 
           subject.send(:get_s3object)


### PR DESCRIPTION
AWS SDK expects symbolized hash keys, so do that.
