### PR TITLE
Remove commas from the s3 input config

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -166,11 +166,11 @@ the connection to s3. See full list in https://docs.aws.amazon.com/sdkforruby/ap
 [source,ruby]
     input {
       s3 {
-        "access_key_id" => "1234",
-        "secret_access_key" => "secret",
-        "bucket" => "logstash-test",
+        "access_key_id" => "1234"
+        "secret_access_key" => "secret"
+        "bucket" => "logstash-test"
         "additional_settings" => {
-          "force_path_style" => true,
+          "force_path_style" => true
           "follow_redirects" => false
         }
       }


### PR DESCRIPTION
I tested with Logstash 6.3.1 and logstash-input-s3 3.3.5. If the commas are part of the config, I get the following error
[2018-07-10T17:16:38,730][ERROR][logstash.agent           ] Failed to execute action {:action=>LogStash::PipelineAction::Create/pipeline_id:main, :exception=>"LogStash::ConfigurationError", :message=>"Expected one of #, {, } at line 4, column 46 (byte 63) after input {\n \n  s3 {\n    \"access_key_id\" ...

without the commas it worked fine.

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
