### PR TITLE
Optionally include object properties inside of [@metadata][s3]

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -44,6 +44,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-delete>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-endpoint>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-exclude_pattern>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-include_object_properties>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-interval>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-prefix>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-proxy_uri>> |<<string,string>>|No
@@ -175,6 +176,15 @@ the connection to s3. See full list in https://docs.aws.amazon.com/sdkforruby/ap
         }
       }
     }
+
+[id="plugins-{type}s-{plugin}-include_object_properties"]
+===== `include_object_properties`
+
+  * Value type is <<boolean,boolean>>
+  * Default value is `false`
+
+Whether or not to include the S3 object's properties (last_modified, content_type, metadata) into each Event at
+`[@metadata][s3]`. Regardless of this setting, `[@metdata][s3][key]` will always be present.
 
 [id="plugins-{type}s-{plugin}-interval"]
 ===== `interval` 


### PR DESCRIPTION
This is a proposal to add a new configuration option `include_object_properties` that allows passing through the S3 object properties such as `etag, content_type, content_encoding, metadata` into the `[metadata][s3]`hash that already exists today. 

For an example use case: we have a number of s3 objects with metadata that we want to use inside our logstash pipeline to target different elastic indices. 