### PR TITLE
Single batch run option: add an interval override for bucket listing.

### DIFF
--- a/lib/logstash/inputs/s3.rb
+++ b/lib/logstash/inputs/s3.rb
@@ -112,13 +112,12 @@ class LogStash::Inputs::S3 < LogStash::Inputs::Base
     @current_thread = Thread.current
     Stud.interval(@interval) do
       process_files(queue)
+      stop unless @watch_for_new_files
     end
   end # def run
 
   public
   def list_new_files
-    stop unless @watch_for_new_files
-    
     objects = {}
     found = false
     begin

--- a/lib/logstash/inputs/s3.rb
+++ b/lib/logstash/inputs/s3.rb
@@ -63,6 +63,10 @@ class LogStash::Inputs::S3 < LogStash::Inputs::Base
   # Value is in seconds.
   config :interval, :validate => :number, :default => 60
 
+  # Whether to watch for new files with the interval. 
+  # If false, overrides any interval and only lists the s3 bucket once.
+  config :watch_for_new_files, :validate => :boolean, :default => true
+
   # Ruby style regexp of keys to exclude from the bucket
   config :exclude_pattern, :validate => :string, :default => nil
 
@@ -113,6 +117,8 @@ class LogStash::Inputs::S3 < LogStash::Inputs::Base
 
   public
   def list_new_files
+    stop unless @watch_for_new_files
+    
     objects = {}
     found = false
     begin


### PR DESCRIPTION
If watch_for_new_files is set to false, the plugin will only list the s3 bucket once and exit after processing completes.

This is consistent with the file Logstash plugin which exits after successfully processing files.

I opened a [ticket](https://github.com/logstash-plugins/logstash-input-s3/issues/159) for discussion. Please review -- I'd like to work with you guys to add this functionality. @yaauie 

- [x] Signed CLA
- [x] Tested under single file and multiple file conditions
- [x] Verified that s3 list only happens once
