### PR TITLE
Add decorate(event) in case of stateful codecs like multiline

### DIFF
--- a/lib/logstash/inputs/s3.rb
+++ b/lib/logstash/inputs/s3.rb
@@ -242,6 +242,7 @@ class LogStash::Inputs::S3 < LogStash::Inputs::Base
     end
     # #ensure any stateful codecs (such as multi-line ) are flushed to the queue
     @codec.flush do |event|
+      decorate(event)
       queue << event
     end
 


### PR DESCRIPTION
The `decorate()` method wasn't being called in case of stateful codecs before en-queuing the event. This resulted in `type`, `tags` and `add_field` options being ineffective when a user uses them with this plugin.
This PR fixes it

See issue #153 

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
