### PR TITLE
Update documentation to reflect changes to syntax

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -63,6 +63,28 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 Also see <<plugins-{type}s-{plugin}-common-options>> for a list of options supported by all
 input plugins.
 
+Note: Syntax has changed from version 6.x to 7.x: keys are no longer encased in double quotes.
+
+Old:
+[source, ruby]
+s3 {
+    "bucket" => "waf-logs-nva"
+    "region" => "us-east-1"
+    "delete" => false
+    "type" => "waf-blocked"
+}
+
+
+New:
+[source, ruby]
+s3 {
+    bucket => "waf-logs-nva"
+    region => "us-east-1"
+    delete => false
+    type => "waf-blocked"
+}
+
+
 &nbsp;
 
 [id="plugins-{type}s-{plugin}-access_key_id"]
@@ -138,6 +160,14 @@ The name of the S3 bucket.
   * Value type is <<boolean,boolean>>
   * Default value is `false`
 
+Example:
+
+[source,ruby]
+----------------------------------
+    delete => true
+----------------------------------
+
+
 Whether to delete processed files from the original bucket.
 
 [id="plugins-{type}s-{plugin}-endpoint"]
@@ -145,6 +175,14 @@ Whether to delete processed files from the original bucket.
 
   * Value type is <<string,string>>
   * There is no default value for this setting.
+
+Example:
+
+[source,ruby]
+----------------------------------
+    region => "example_log_bucket"
+----------------------------------
+
 
 The endpoint to connect to. By default it is constructed using the value of `region`.
 This is useful when connecting to S3 compatible services, but beware that these aren't
@@ -170,10 +208,10 @@ the connection to s3. See full list in https://docs.aws.amazon.com/sdkforruby/ap
 [source,ruby]
     input {
       s3 {
-        "access_key_id" => "1234"
-        "secret_access_key" => "secret"
-        "bucket" => "logstash-test"
-        "additional_settings" => {
+        access_key_id => "1234"
+        secret_access_key => "secret"
+        bucket => "logstash-test"
+        additional_settings => {
           "force_path_style" => true
           "follow_redirects" => false
         }
@@ -219,6 +257,14 @@ URI to proxy server if required
 
   * Value type is <<string,string>>
   * Default value is `"us-east-1"`
+
+Example:
+
+[source,ruby]
+----------------------------------
+    region => "eu-west-1"
+----------------------------------
+
 
 The AWS Region
 


### PR DESCRIPTION
Updated to add in a note about syntax changing from version 6.x to 7.x, from double-quote-wrapped keys, to un-quoted keys in the key => value pairs. Added an example of old syntax vs. new for clarity, added a few examples for different keys. I know I ran into an issue with my logstash refusing to process events because it didn't understand settings for the s3 buckets if they were quote wrapped, even though it worked fine in 6.5.4.  Hoping this clears up that issue for anyone else who might run into it.

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
