### PR TITLE
Ignore objects in Glacier deep archive

### DIFF
--- a/lib/logstash/inputs/s3.rb
+++ b/lib/logstash/inputs/s3.rb
@@ -134,7 +134,7 @@ class LogStash::Inputs::S3 < LogStash::Inputs::Base
           @logger.debug('S3 Input: Object Zero Length', :key => log.key)
         elsif !sincedb.newer?(log.last_modified)
           @logger.debug('S3 Input: Object Not Modified', :key => log.key)
-        elsif log.storage_class.start_with?('GLACIER')
+        elsif %w(GLACIER DEEP_ARCHIVE).include?(log.storage_class)
           @logger.debug('S3 Input: Object Archived to Glacier', :key => log.key)
         else
           objects[log.key] = log.last_modified

--- a/spec/inputs/s3_spec.rb
+++ b/spec/inputs/s3_spec.rb
@@ -116,6 +116,7 @@ describe LogStash::Inputs::S3 do
 
     let!(:present_object) { double(:key => 'this-should-be-present', :last_modified => Time.now, :content_length => 10, :storage_class => 'STANDARD') }
     let!(:archived_object) {double(:key => 'this-should-be-archived', :last_modified => Time.now, :content_length => 10, :storage_class => 'GLACIER') }
+    let!(:deep_archived_object) {double(:key => 'this-should-also-be-archived', :last_modified => Time.now, :content_length => 10, :storage_class => 'DEEP_ARCHIVE') }
     let(:objects_list) {
       [
         double(:key => 'exclude-this-file-1', :last_modified => Time.now - 2 * day, :content_length => 100, :storage_class => 'STANDARD'),
@@ -134,6 +135,7 @@ describe LogStash::Inputs::S3 do
       expect(files).to_not include('exclude-this-file-1') # matches exclude pattern
       expect(files).to_not include('exclude/logstash')    # matches exclude pattern
       expect(files).to_not include(archived_object.key)   # archived
+      expect(files).to_not include(deep_archived_object.key) # archived
       expect(files.size).to eq(1)
     end
 


### PR DESCRIPTION
Different storage class (DEEP_ARCHIVE) to standard Glacier (GLACIER).

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
