### PR TITLE
Commit to add is_gzipped into the mix for making optional checks on compressed files without gz extensions.

### DIFF
--- a/lib/logstash/inputs/s3.rb
+++ b/lib/logstash/inputs/s3.rb
@@ -79,6 +79,9 @@ class LogStash::Inputs::S3 < LogStash::Inputs::Base
   # be present.
   config :include_object_properties, :validate => :boolean, :default => false
 
+  # Pass boolean to see if the source file may not have the .gz extension but is actually zipped.
+  config :is_gzipped, :validate => :boolean, :default => false
+
   public
   def register
     require "fileutils"
@@ -315,7 +318,7 @@ class LogStash::Inputs::S3 < LogStash::Inputs::Base
 
   private
   def gzip?(filename)
-    filename.end_with?('.gz','.gzip')
+    filename.end_with?('.gz','.gzip') or @is_gzipped
   end
   
   private

--- a/logstash-input-s3.gemspec
+++ b/logstash-input-s3.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-s3'
-  s.version         = '3.4.1'
+  s.version         = '3.4.2'
   s.licenses        = ['Apache-2.0']
   s.summary         = "Streams events from files in a S3 bucket"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Hi Team,

In regards to the issue previously raised under 

https://github.com/logstash-plugins/logstash-input-s3/issues/180

I have created a pull request to merge the changes of adding support of gz files even though the file extension may not be .gz. Please review and advise is the above can be merged to master. 

Regards,
Arpan

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
