### PR TITLE
Allow multiple logstash instances

### DIFF
--- a/lib/logstash/inputs/s3.rb
+++ b/lib/logstash/inputs/s3.rb
@@ -80,8 +80,8 @@ class LogStash::Inputs::S3 < LogStash::Inputs::Base
   config :include_object_properties, :validate => :boolean, :default => false
 
   # Whether to sort the files before processing them or not.
-  # Set this value to false if you want to run multiple Logstash
-  # instances on the same bucket.
+  #
+  # Set this value to false if you want to run multiple Logstash instances on the same bucket.
   config :sort_processed_files, :validate => :boolean, :default => true
 
   public
@@ -410,12 +410,12 @@ class LogStash::Inputs::S3 < LogStash::Inputs::Base
         rescue
           @logger.warn("S3 input: Remote file not available anymore", :remote_key => key)
         end
+        FileUtils.remove_entry_secure(filename, true)
         if @sort_processed_files
           # Keeping track of the processed files only makes sense
           # if they were processed in a chronological order.
           sincedb.write(lastmod)
         end
-        FileUtils.remove_entry_secure(filename, true)
       end
     else
       FileUtils.remove_entry_secure(filename, true)

--- a/lib/logstash/inputs/s3.rb
+++ b/lib/logstash/inputs/s3.rb
@@ -146,7 +146,7 @@ class LogStash::Inputs::S3 < LogStash::Inputs::Base
     rescue Aws::Errors::ServiceError => e
       @logger.error("S3 input: Unable to list objects in bucket", :prefix => prefix, :message => e.message)
     end
-    objects.keys.sort {|a,b| objects[a] <=> objects[b]}
+    objects.keys.shuffle {|a,b| objects[a] <=> objects[b]}
   end # def fetch_new_files
 
   public

--- a/logstash-input-s3.gemspec
+++ b/logstash-input-s3.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-s3'
-  s.version         = '3.4.1'
+  s.version         = '3.5.0'
   s.licenses        = ['Apache-2.0']
   s.summary         = "Streams events from files in a S3 bucket"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
#### What this PR does / why we need it
To allow scaling logs processing from a single S3 bucket by running multiple Logstash instances with S3 Input Plugin (an open issue since 2015 : https://discuss.elastic.co/t/multiple-logstash-docker-containers-sharing-an-s3-input/36077/2)

#### Special notes for the reviewers
Using the current version of this plugin, if you run multiple instances they will all end up processing the same file due to the fact that the list of S3 objects is always "sorted" before starting the processing.

This PR allows the user to decide whether to sort the files (by name/s3 object key) before starting the processing (current behavior) or shuffle the list of objects to minimize the possibility of contention between multiple instances.

The main change in this PR is small : https://github.com/logstash-plugins/logstash-input-s3/commit/4dc4e9d45b966454da02127eaeafd910cac3e9b5 which is an optimistic locking ... kind of. All other changes are for error handling or to make the change introduced by this PR configurable.