### PR TITLE
Define cut-off time in list_new_files to prevent recently-modified files being missed

### DIFF
--- a/lib/logstash/inputs/s3.rb
+++ b/lib/logstash/inputs/s3.rb
@@ -139,8 +139,8 @@ class LogStash::Inputs::S3 < LogStash::Inputs::Base
           @logger.debug('S3 Input: Object Zero Length', :key => log.key)
         elsif !sincedb.newer?(log.last_modified)
           @logger.debug('S3 Input: Object Not Modified', :key => log.key)
-	      elsif log.last_modified > cutoff_time
-	        @logger.debug('S3 Input: Object Too Recent', :key => log.key)
+        elsif log.last_modified > cutoff_time
+          @logger.debug('S3 Input: Object Too Recent', :key => log.key)
         elsif log.storage_class.start_with?('GLACIER')
           @logger.debug('S3 Input: Object Archived to Glacier', :key => log.key)
         else

--- a/lib/logstash/inputs/s3.rb
+++ b/lib/logstash/inputs/s3.rb
@@ -139,8 +139,8 @@ class LogStash::Inputs::S3 < LogStash::Inputs::Base
           @logger.debug('S3 Input: Object Zero Length', :key => log.key)
         elsif !sincedb.newer?(log.last_modified)
           @logger.debug('S3 Input: Object Not Modified', :key => log.key)
-	elsif log.last_modified > cutoff_time
-	  @logger.debug('S3 Input: Object Too Recent', :key => log.key)
+	      elsif log.last_modified > cutoff_time
+	        @logger.debug('S3 Input: Object Too Recent', :key => log.key)
         elsif log.storage_class.start_with?('GLACIER')
           @logger.debug('S3 Input: Object Archived to Glacier', :key => log.key)
         else


### PR DESCRIPTION
Fix for the bug detailed in https://github.com/logstash-plugins/logstash-input-s3/issues/57

When there are multiple files created with the same timestamp, it is possible that some of them are added to S3 after list_new_files has already run. The sincedb is then updated with that timestamp, so the newly-added files are not picked up on the next run.

With this change, any files modified within the last 2 seconds will not be considered and a debug log is written to say the object was modified too recently.