### PR TITLE
Add setting to skip the sincedb timestamp check

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -56,7 +56,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-secret_access_key>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-session_token>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-sincedb_path>> |<<string,string>>|No
-| <<plugins-{type}s-{plugin}-sincedb_disabled>> |<<boolean,boolean>>|No
+| <<plugins-{type}s-{plugin}-sincedb_ignore>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-temporary_directory>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-watch_for_new_files>> |<<boolean,boolean>>|No
 |=======================================================================
@@ -269,8 +269,8 @@ sincedb files to in the directory '{path.data}/plugins/inputs/s3/'
 
 If specified, this setting must be a filename path and not just a directory.
 
-[id="plugins-{type}s-{plugin}-sincedb_disabled"]
-===== `sincedb_disabled` 
+[id="plugins-{type}s-{plugin}-sincedb_ignore"]
+===== `sincedb_ignore` 
 
   * Value type is <<boolean,boolean>>
   * Default value is `false`

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -56,6 +56,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-secret_access_key>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-session_token>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-sincedb_path>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-sincedb_disabled>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-temporary_directory>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-watch_for_new_files>> |<<boolean,boolean>>|No
 |=======================================================================
@@ -267,6 +268,16 @@ the last handled file was added to S3). The default will write
 sincedb files to in the directory '{path.data}/plugins/inputs/s3/'
 
 If specified, this setting must be a filename path and not just a directory.
+
+[id="plugins-{type}s-{plugin}-sincedb_disabled"]
+===== `sincedb_disabled` 
+
+  * Value type is <<boolean,boolean>>
+  * Default value is `false`
+
+When this setting is set to true, the date stored in sincedb is not used to 
+determine whether a file should be processed. This setting is particularly 
+useful when you are moving/deleting files after initial processing.
 
 [id="plugins-{type}s-{plugin}-temporary_directory"]
 ===== `temporary_directory` 

--- a/lib/logstash/inputs/s3.rb
+++ b/lib/logstash/inputs/s3.rb
@@ -81,7 +81,7 @@ class LogStash::Inputs::S3 < LogStash::Inputs::Base
   
   # When this setting is enabled, the date stored in sincedb is not used to determine whether a file should be processed.
   # This setting is particularly useful when you are moving/deleting files after initial processing.
-  config :sincedb_disabled, :validate => :boolean, :default => false
+  config :sincedb_ignore, :validate => :boolean, :default => false
 
   public
   def register
@@ -113,8 +113,8 @@ class LogStash::Inputs::S3 < LogStash::Inputs::Base
     if !@watch_for_new_files && original_params.include?('interval')
       logger.warn("`watch_for_new_files` has been disabled; `interval` directive will be ignored.")
     end
-    if @sincedb_disabled
-      logger.warn("`sincedb_disabled` has been set to  `true`; `sincedb` checking will be ignored, if you are not using `delete` this may result in duplicate processing.")
+    if @sincedb_ignore
+      logger.warn("`sincedb_ignore` has been set to  `true`; `sincedb` checking will be ignored, if you are not using `delete` this may result in duplicate processing.")
     end
   end
 
@@ -139,7 +139,7 @@ class LogStash::Inputs::S3 < LogStash::Inputs::Base
           @logger.debug('S3 input: Ignoring', :key => log.key)
         elsif log.content_length <= 0
           @logger.debug('S3 Input: Object Zero Length', :key => log.key)
-        elsif !@sincedb_disabled && !sincedb.newer?(log.last_modified)
+        elsif !@sincedb_ignore && !sincedb.newer?(log.last_modified)
           @logger.debug('S3 Input: Object Not Modified', :key => log.key)
         elsif log.storage_class.start_with?('GLACIER')
           @logger.debug('S3 Input: Object Archived to Glacier', :key => log.key)

--- a/lib/logstash/inputs/s3.rb
+++ b/lib/logstash/inputs/s3.rb
@@ -113,6 +113,9 @@ class LogStash::Inputs::S3 < LogStash::Inputs::Base
     if !@watch_for_new_files && original_params.include?('interval')
       logger.warn("`watch_for_new_files` has been disabled; `interval` directive will be ignored.")
     end
+    if @sincedb_disabled
+      logger.warn("`sincedb_disabled` has been set to  `true`; `sincedb` checking will be ignored, if you are not using `delete` this may result in duplicate processing.")
+    end
   end
 
   public

--- a/lib/logstash/inputs/s3.rb
+++ b/lib/logstash/inputs/s3.rb
@@ -78,6 +78,10 @@ class LogStash::Inputs::S3 < LogStash::Inputs::Base
   # into each Event at [@metadata][s3]. Regardless of this setting, [@metdata][s3][key] will always
   # be present.
   config :include_object_properties, :validate => :boolean, :default => false
+  
+  # When this setting is enabled, the date stored in sincedb is not used to determine whether a file should be processed.
+  # This setting is particularly useful when you are moving/deleting files after initial processing.
+  config :sincedb_disabled, :validate => :boolean, :default => false
 
   public
   def register
@@ -132,7 +136,7 @@ class LogStash::Inputs::S3 < LogStash::Inputs::Base
           @logger.debug('S3 input: Ignoring', :key => log.key)
         elsif log.content_length <= 0
           @logger.debug('S3 Input: Object Zero Length', :key => log.key)
-        elsif !sincedb.newer?(log.last_modified)
+        elsif !@sincedb_disabled && !sincedb.newer?(log.last_modified)
           @logger.debug('S3 Input: Object Not Modified', :key => log.key)
         elsif log.storage_class.start_with?('GLACIER')
           @logger.debug('S3 Input: Object Archived to Glacier', :key => log.key)


### PR DESCRIPTION
Adding a new setting that allows a user to configure the sincedb timestamp check to be skipped. This is useful when the delete mode is in enabled and resolves issues where multiple files with the same last modified timestamp are currently not processed in a reliable manner (#57 #191).

The `sincedb_ignore` setting should not be set to true unless `delete` is also set to true, otherwise the same files could be repeatedly process.

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
