### PR TITLE
Refactor: scope java_import statements

### DIFF
--- a/lib/logstash/inputs/s3.rb
+++ b/lib/logstash/inputs/s3.rb
@@ -10,12 +10,6 @@ require "aws-sdk"
 require "logstash/inputs/s3/patch"
 
 require 'java'
-java_import java.io.InputStream
-java_import java.io.InputStreamReader
-java_import java.io.FileInputStream
-java_import java.io.BufferedReader
-java_import java.util.zip.GZIPInputStream
-java_import java.util.zip.ZipException
 
 Aws.eager_autoload!
 # Stream events from files from a S3 bucket.
@@ -23,6 +17,14 @@ Aws.eager_autoload!
 # Each line from each file generates an event.
 # Files ending in `.gz` are handled as gzip'ed files.
 class LogStash::Inputs::S3 < LogStash::Inputs::Base
+
+  java_import java.io.InputStream
+  java_import java.io.InputStreamReader
+  java_import java.io.FileInputStream
+  java_import java.io.BufferedReader
+  java_import java.util.zip.GZIPInputStream
+  java_import java.util.zip.ZipException
+
   include LogStash::PluginMixins::AwsConfig::V2
 
   config_name "s3"
@@ -63,7 +65,7 @@ class LogStash::Inputs::S3 < LogStash::Inputs::Base
   # Value is in seconds.
   config :interval, :validate => :number, :default => 60
 
-  # Whether to watch for new files with the interval. 
+  # Whether to watch for new files with the interval.
   # If false, overrides any interval and only lists the s3 bucket once.
   config :watch_for_new_files, :validate => :boolean, :default => true
 
@@ -265,7 +267,7 @@ class LogStash::Inputs::S3 < LogStash::Inputs::Base
     line.start_with?('#Fields: ')
   end
 
-  private 
+  private
   def update_metadata(metadata, event)
     line = event.get('message').strip
 
@@ -317,9 +319,9 @@ class LogStash::Inputs::S3 < LogStash::Inputs::Base
   def gzip?(filename)
     filename.end_with?('.gz','.gzip')
   end
-  
+
   private
-  def sincedb 
+  def sincedb
     @sincedb ||= if @sincedb_path.nil?
                     @logger.info("Using default generated file for the sincedb", :filename => sincedb_file)
                     SinceDB::File.new(sincedb_file)


### PR DESCRIPTION
to not pollute global scope (due potential conflicts)
