### PR TITLE
Only AWS S3 is supported

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -23,6 +23,8 @@ include::{include_path}/plugin_header.asciidoc[]
 
 Stream events from files from a S3 bucket.
 
+IMPORTANT: The S3 input plugin only supports AWS S3. Other S3 compatible storage solutions are not supported.
+
 Each line from each file generates an event.
 Files ending in `.gz` are handled as gzip'ed files.
 


### PR DESCRIPTION
We only support AWS S3, not other S3 compatible storage solutions. This is currently documented in the support matrix (https://www.elastic.co/support/matrix#matrix_logstash_plugins). It should be documented directly in the plugin guide as well (for the support matrix can be missed).

Please merge to all branches. thx!

