### PR TITLE
Fix missing file ingestion in same second

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.5.3
+ - Fixed unprocessed file with the same `last_modified` in ingestion. [#220](https://github.com/logstash-plugins/logstash-input-s3/pull/220)
+
 ## 3.5.2
  - [DOC]Added note that only AWS S3 is supported. No other S3 compatible storage solutions are supported. [#208](https://github.com/logstash-plugins/logstash-input-s3/issues/208)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 3.5.3
+## 3.6.0
  - Fixed unprocessed file with the same `last_modified` in ingestion. [#220](https://github.com/logstash-plugins/logstash-input-s3/pull/220)
 
 ## 3.5.2

--- a/lib/logstash/inputs/s3.rb
+++ b/lib/logstash/inputs/s3.rb
@@ -140,7 +140,7 @@ class LogStash::Inputs::S3 < LogStash::Inputs::Base
           @logger.debug('Object Zero Length', :key => log.key)
         elsif !sincedb.newer?(log.last_modified)
           @logger.debug('Object Not Modified', :key => log.key)
-        elsif log.last_modified > (Time.now - CUTOFF_SECOND).utc # modify time within last two seconds will be processed in next cycle
+        elsif log.last_modified > (Time.now - CUTOFF_SECOND).utc # file modified within last two seconds will be processed in next cycle
           @logger.debug('Object Modified After Cutoff Time', :key => log.key)
         elsif (log.storage_class == 'GLACIER' || log.storage_class == 'DEEP_ARCHIVE') && !file_restored?(log.object)
           @logger.debug('Object Archived to Glacier', :key => log.key)

--- a/lib/logstash/inputs/s3.rb
+++ b/lib/logstash/inputs/s3.rb
@@ -86,6 +86,8 @@ class LogStash::Inputs::S3 < LogStash::Inputs::Base
   # default to an expression that matches *.gz and *.gzip file extensions
   config :gzip_pattern, :validate => :string, :default => "\.gz(ip)?$"
 
+  CUTOFF_SECOND = 3
+
   def register
     require "fileutils"
     require "digest/md5"
@@ -126,7 +128,7 @@ class LogStash::Inputs::S3 < LogStash::Inputs::Base
   end # def run
 
   def list_new_files
-    objects = {}
+    objects = []
     found = false
     begin
       @s3bucket.objects(:prefix => @prefix).each do |log|
@@ -138,10 +140,12 @@ class LogStash::Inputs::S3 < LogStash::Inputs::Base
           @logger.debug('Object Zero Length', :key => log.key)
         elsif !sincedb.newer?(log.last_modified)
           @logger.debug('Object Not Modified', :key => log.key)
+        elsif log.last_modified > (Time.now - CUTOFF_SECOND).utc # modify time within last two seconds will be processed in next cycle
+          @logger.debug('Object Modified After Cutoff Time', :key => log.key)
         elsif (log.storage_class == 'GLACIER' || log.storage_class == 'DEEP_ARCHIVE') && !file_restored?(log.object)
           @logger.debug('Object Archived to Glacier', :key => log.key)
         else
-          objects[log.key] = log.last_modified
+          objects << log
           @logger.debug("Added to objects[]", :key => log.key, :length => objects.length)
         end
       end
@@ -149,7 +153,7 @@ class LogStash::Inputs::S3 < LogStash::Inputs::Base
     rescue Aws::Errors::ServiceError => e
       @logger.error("Unable to list objects in bucket", :exception => e.class, :message => e.message, :backtrace => e.backtrace, :prefix => prefix)
     end
-    objects.keys.sort {|a,b| objects[a] <=> objects[b]}
+    objects.sort_by { |log| log.last_modified }
   end # def fetch_new_files
 
   def backup_to_bucket(object)
@@ -171,11 +175,11 @@ class LogStash::Inputs::S3 < LogStash::Inputs::Base
   def process_files(queue)
     objects = list_new_files
 
-    objects.each do |key|
+    objects.each do |log|
       if stop?
         break
       else
-        process_log(queue, key)
+        process_log(queue, log)
       end
     end
   end # def process_files
@@ -367,19 +371,18 @@ class LogStash::Inputs::S3 < LogStash::Inputs::Base
     end
   end
 
-  def process_log(queue, key)
-    @logger.debug("Processing", :bucket => @bucket, :key => key)
-    object = @s3bucket.object(key)
+  def process_log(queue, log)
+    @logger.debug("Processing", :bucket => @bucket, :key => log.key)
+    object = @s3bucket.object(log.key)
 
-    filename = File.join(temporary_directory, File.basename(key))
+    filename = File.join(temporary_directory, File.basename(log.key))
     if download_remote_file(object, filename)
       if process_local_log(queue, filename, object)
-        lastmod = object.last_modified
         backup_to_bucket(object)
         backup_to_dir(filename)
         delete_file_from_bucket(object)
         FileUtils.remove_entry_secure(filename, true)
-        sincedb.write(lastmod)
+        sincedb.write(log.last_modified)
       end
     else
       FileUtils.remove_entry_secure(filename, true)

--- a/logstash-input-s3.gemspec
+++ b/logstash-input-s3.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-s3'
-  s.version         = '3.5.2'
+  s.version         = '3.5.3'
   s.licenses        = ['Apache-2.0']
   s.summary         = "Streams events from files in a S3 bucket"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/logstash-input-s3.gemspec
+++ b/logstash-input-s3.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-s3'
-  s.version         = '3.5.3'
+  s.version         = '3.6.0'
   s.licenses        = ['Apache-2.0']
   s.summary         = "Streams events from files in a S3 bucket"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/inputs/s3_spec.rb
+++ b/spec/inputs/s3_spec.rb
@@ -24,6 +24,7 @@ describe LogStash::Inputs::S3 do
       "sincedb_path" => File.join(sincedb_path, ".sincedb")
     }
   }
+  let(:cutoff) { LogStash::Inputs::S3::CUTOFF_SECOND }
 
 
   before do
@@ -34,9 +35,10 @@ describe LogStash::Inputs::S3 do
 
   context "when interrupting the plugin" do
     let(:config) { super.merge({ "interval" => 5 }) }
+    let(:s3_obj) { double(:key => "awesome-key", :last_modified => Time.now.round, :content_length => 10, :storage_class => 'STANDARD', :object => double(:data => double(:restore => nil)) ) }
 
     before do
-      expect_any_instance_of(LogStash::Inputs::S3).to receive(:list_new_files).and_return(TestInfiniteS3Object.new)
+      expect_any_instance_of(LogStash::Inputs::S3).to receive(:list_new_files).and_return(TestInfiniteS3Object.new(s3_obj))
     end
 
     it_behaves_like "an interruptible input plugin"
@@ -115,11 +117,12 @@ describe LogStash::Inputs::S3 do
   describe "#list_new_files" do
     before { allow_any_instance_of(Aws::S3::Bucket).to receive(:objects) { objects_list } }
 
-    let!(:present_object) {double(:key => 'this-should-be-present', :last_modified => Time.now, :content_length => 10, :storage_class => 'STANDARD', :object => double(:data => double(:restore => nil)) ) }
-    let!(:archived_object) {double(:key => 'this-should-be-archived', :last_modified => Time.now, :content_length => 10, :storage_class => 'GLACIER', :object => double(:data => double(:restore => nil)) ) }
-    let!(:deep_archived_object) {double(:key => 'this-should-be-archived', :last_modified => Time.now, :content_length => 10, :storage_class => 'GLACIER', :object => double(:data => double(:restore => nil)) ) }
-    let!(:restored_object) {double(:key => 'this-should-be-restored-from-archive', :last_modified => Time.now, :content_length => 10, :storage_class => 'GLACIER', :object => double(:data => double(:restore => 'ongoing-request="false", expiry-date="Thu, 01 Jan 2099 00:00:00 GMT"')) ) }
-    let!(:deep_restored_object) {double(:key => 'this-should-be-restored-from-deep-archive', :last_modified => Time.now, :content_length => 10, :storage_class => 'DEEP_ARCHIVE', :object => double(:data => double(:restore => 'ongoing-request="false", expiry-date="Thu, 01 Jan 2099 00:00:00 GMT"')) ) }
+    let!(:present_object_after_cutoff) {double(:key => 'this-should-not-be-present', :last_modified => Time.now, :content_length => 10, :storage_class => 'STANDARD', :object => double(:data => double(:restore => nil)) ) }
+    let!(:present_object) {double(:key => 'this-should-be-present', :last_modified => Time.now - cutoff, :content_length => 10, :storage_class => 'STANDARD', :object => double(:data => double(:restore => nil)) ) }
+    let!(:archived_object) {double(:key => 'this-should-be-archived', :last_modified => Time.now  - cutoff, :content_length => 10, :storage_class => 'GLACIER', :object => double(:data => double(:restore => nil)) ) }
+    let!(:deep_archived_object) {double(:key => 'this-should-be-archived', :last_modified => Time.now - cutoff, :content_length => 10, :storage_class => 'GLACIER', :object => double(:data => double(:restore => nil)) ) }
+    let!(:restored_object) {double(:key => 'this-should-be-restored-from-archive', :last_modified => Time.now  - cutoff, :content_length => 10, :storage_class => 'GLACIER', :object => double(:data => double(:restore => 'ongoing-request="false", expiry-date="Thu, 01 Jan 2099 00:00:00 GMT"')) ) }
+    let!(:deep_restored_object) {double(:key => 'this-should-be-restored-from-deep-archive', :last_modified => Time.now  - cutoff, :content_length => 10, :storage_class => 'DEEP_ARCHIVE', :object => double(:data => double(:restore => 'ongoing-request="false", expiry-date="Thu, 01 Jan 2099 00:00:00 GMT"')) ) }
     let(:objects_list) {
       [
         double(:key => 'exclude-this-file-1', :last_modified => Time.now - 2 * day, :content_length => 100, :storage_class => 'STANDARD'),
@@ -127,7 +130,8 @@ describe LogStash::Inputs::S3 do
         archived_object,
         restored_object,
         deep_restored_object,
-        present_object
+        present_object,
+        present_object_after_cutoff
       ]
     }
 
@@ -135,7 +139,7 @@ describe LogStash::Inputs::S3 do
       plugin = LogStash::Inputs::S3.new(config.merge({ "exclude_pattern" => "^exclude" }))
       plugin.register
 
-      files = plugin.list_new_files
+      files = plugin.list_new_files.map { |item| item.key }
       expect(files).to include(present_object.key)
       expect(files).to include(restored_object.key)
       expect(files).to include(deep_restored_object.key)
@@ -143,6 +147,7 @@ describe LogStash::Inputs::S3 do
       expect(files).to_not include('exclude/logstash')    # matches exclude pattern
       expect(files).to_not include(archived_object.key)   # archived
       expect(files).to_not include(deep_archived_object.key)   # archived
+      expect(files).to_not include(present_object_after_cutoff.key)   # after cutoff
       expect(files.size).to eq(3)
     end
 
@@ -150,7 +155,7 @@ describe LogStash::Inputs::S3 do
       plugin = LogStash::Inputs::S3.new(config)
       plugin.register
 
-      files = plugin.list_new_files
+      files = plugin.list_new_files.map { |item| item.key }
       expect(files).to include(present_object.key)
       expect(files).to include(restored_object.key)
       expect(files).to include(deep_restored_object.key)
@@ -158,6 +163,7 @@ describe LogStash::Inputs::S3 do
       expect(files).to include('exclude/logstash')      # no exclude pattern given
       expect(files).to_not include(archived_object.key) # archived
       expect(files).to_not include(deep_archived_object.key)   # archived
+      expect(files).to_not include(present_object_after_cutoff.key)   # after cutoff
       expect(files.size).to eq(5)
     end
 
@@ -204,7 +210,7 @@ describe LogStash::Inputs::S3 do
                                                          'backup_to_bucket' => config['bucket']}))
         plugin.register
 
-        files = plugin.list_new_files
+        files = plugin.list_new_files.map { |item| item.key }
         expect(files).to include(present_object.key)
         expect(files).to_not include('mybackup-log-1') # matches backup prefix
         expect(files.size).to eq(1)
@@ -218,7 +224,7 @@ describe LogStash::Inputs::S3 do
       allow_any_instance_of(LogStash::Inputs::S3::SinceDB::File).to receive(:read).and_return(Time.now - day)
       plugin.register
 
-      files = plugin.list_new_files
+      files = plugin.list_new_files.map { |item| item.key }
       expect(files).to include(present_object.key)
       expect(files).to include(restored_object.key)
       expect(files).to include(deep_restored_object.key)
@@ -226,6 +232,7 @@ describe LogStash::Inputs::S3 do
       expect(files).to_not include('exclude/logstash')    # too old
       expect(files).to_not include(archived_object.key)   # archived
       expect(files).to_not include(deep_archived_object.key) # archived
+      expect(files).to_not include(present_object_after_cutoff.key)   # after cutoff
       expect(files.size).to eq(3)
     end
 
@@ -241,13 +248,14 @@ describe LogStash::Inputs::S3 do
 
         plugin = LogStash::Inputs::S3.new(config.merge({ 'prefix' => prefix }))
         plugin.register
-        expect(plugin.list_new_files).to eq([present_object.key])
+        expect(plugin.list_new_files.map { |item| item.key }).to eq([present_object.key])
     end
 
     it 'should sort return object sorted by last_modification date with older first' do
       objects = [
         double(:key => 'YESTERDAY', :last_modified => Time.now - day, :content_length => 5, :storage_class => 'STANDARD'),
         double(:key => 'TODAY', :last_modified => Time.now, :content_length => 5, :storage_class => 'STANDARD'),
+        double(:key => 'TODAY_BEFORE_CUTOFF', :last_modified => Time.now - cutoff, :content_length => 5, :storage_class => 'STANDARD'),
         double(:key => 'TWO_DAYS_AGO', :last_modified => Time.now - 2 * day, :content_length => 5, :storage_class => 'STANDARD')
       ]
 
@@ -256,7 +264,7 @@ describe LogStash::Inputs::S3 do
 
       plugin = LogStash::Inputs::S3.new(config)
       plugin.register
-      expect(plugin.list_new_files).to eq(['TWO_DAYS_AGO', 'YESTERDAY', 'TODAY'])
+      expect(plugin.list_new_files.map { |item| item.key }).to eq(['TWO_DAYS_AGO', 'YESTERDAY', 'TODAY_BEFORE_CUTOFF'])
     end
 
     describe "when doing backup on the s3" do
@@ -525,6 +533,67 @@ describe LogStash::Inputs::S3 do
 
       include_examples "generated events"
     end
+  end
 
+  describe "data loss" do
+    let(:s3_plugin) { LogStash::Inputs::S3.new(config) }
+    let(:queue) { [] }
+
+    before do
+      s3_plugin.register
+    end
+
+    context 'events come after cutoff time' do
+      it 'should be processed in next cycle' do
+        s3_objects = [
+          double(:key => 'TWO_DAYS_AGO', :last_modified => Time.now.round - 2 * day, :content_length => 5, :storage_class => 'STANDARD'),
+          double(:key => 'YESTERDAY', :last_modified => Time.now.round - day, :content_length => 5, :storage_class => 'STANDARD'),
+          double(:key => 'TODAY_BEFORE_CUTOFF', :last_modified => Time.now.round - cutoff, :content_length => 5, :storage_class => 'STANDARD'),
+          double(:key => 'TODAY', :last_modified => Time.now.round, :content_length => 5, :storage_class => 'STANDARD'),
+          double(:key => 'TODAY', :last_modified => Time.now.round, :content_length => 5, :storage_class => 'STANDARD')
+        ]
+        size = s3_objects.length
+
+        allow_any_instance_of(Aws::S3::Bucket).to receive(:objects) { s3_objects }
+        allow_any_instance_of(Aws::S3::Bucket).to receive(:object).and_return(*s3_objects)
+        expect(s3_plugin).to receive(:process_log).at_least(size).and_call_original
+        expect(s3_plugin).to receive(:stop?).and_return(false).at_least(size)
+        expect(s3_plugin).to receive(:download_remote_file).and_return(true).at_least(size)
+        expect(s3_plugin).to receive(:process_local_log).and_return(true).at_least(size)
+
+        # first iteration
+        s3_plugin.process_files(queue)
+
+        # second iteration
+        sleep(cutoff + 1)
+        s3_plugin.process_files(queue)
+      end
+    end
+
+    context 's3 object updated after getting summary' do
+      it 'should use summary timestamp as sincedb' do
+        s3_summary = [
+          double(:key => 'YESTERDAY', :last_modified => Time.now.round - day, :content_length => 5, :storage_class => 'STANDARD'),
+          double(:key => 'TODAY', :last_modified => Time.now.round - (cutoff * 10), :content_length => 5, :storage_class => 'STANDARD')
+        ]
+
+        s3_objects = [
+          double(:key => 'YESTERDAY', :last_modified => Time.now.round - day, :content_length => 5, :storage_class => 'STANDARD'),
+          double(:key => 'TODAY_UPDATED', :last_modified => Time.now.round, :content_length => 5, :storage_class => 'STANDARD')
+        ]
+
+        size = s3_objects.length
+
+        allow_any_instance_of(Aws::S3::Bucket).to receive(:objects) { s3_summary }
+        allow_any_instance_of(Aws::S3::Bucket).to receive(:object).and_return(*s3_objects)
+        expect(s3_plugin).to receive(:process_log).at_least(size).and_call_original
+        expect(s3_plugin).to receive(:stop?).and_return(false).at_least(size)
+        expect(s3_plugin).to receive(:download_remote_file).and_return(true).at_least(size)
+        expect(s3_plugin).to receive(:process_local_log).and_return(true).at_least(size)
+
+        s3_plugin.process_files(queue)
+        expect(s3_plugin.send(:sincedb).read).to eq(s3_summary[1].last_modified)
+      end
+    end
   end
 end

--- a/spec/inputs/s3_spec.rb
+++ b/spec/inputs/s3_spec.rb
@@ -571,7 +571,7 @@ describe LogStash::Inputs::S3 do
     end
 
     context 's3 object updated after getting summary' do
-      it 'should use summary timestamp as sincedb' do
+      it 'should not update sincedb' do
         s3_summary = [
           double(:key => 'YESTERDAY', :last_modified => Time.now.round - day, :content_length => 5, :storage_class => 'STANDARD'),
           double(:key => 'TODAY', :last_modified => Time.now.round - (cutoff * 10), :content_length => 5, :storage_class => 'STANDARD')
@@ -592,7 +592,7 @@ describe LogStash::Inputs::S3 do
         expect(s3_plugin).to receive(:process_local_log).and_return(true).at_least(size)
 
         s3_plugin.process_files(queue)
-        expect(s3_plugin.send(:sincedb).read).to eq(s3_summary[1].last_modified)
+        expect(s3_plugin.send(:sincedb).read).to eq(s3_summary[0].last_modified)
       end
     end
   end

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -23,6 +23,10 @@ def list_remote_files(prefix, target_bucket = ENV['AWS_LOGSTASH_TEST_BUCKET'])
   bucket.objects(:prefix => prefix).collect(&:key)
 end
 
+def create_bucket(name)
+  s3object.bucket(name).create
+end
+
 def delete_bucket(name)
   s3object.bucket(name).objects.map(&:delete)
   s3object.bucket(name).delete
@@ -33,13 +37,16 @@ def s3object
 end
 
 class TestInfiniteS3Object
+  def initialize(s3_obj)
+    @s3_obj = s3_obj
+  end
+
   def each
     counter = 1
 
     loop do
-      yield "awesome-#{counter}"
+      yield @s3_obj
       counter +=1
     end
   end
 end
-


### PR DESCRIPTION
This PR makes two changes to fix the unprocessed file
1. Take the `last_modified` from s3 [summary](https://github.com/logstash-plugins/logstash-input-s3/blob/master/lib/logstash/inputs/s3.rb#L132) instead of [details](https://github.com/logstash-plugins/logstash-input-s3/blob/master/lib/logstash/inputs/s3.rb#L372)
In the original implementation, the time difference of the same iteration between summary (t1) and details (t2) could be long depending on the file size. Meanwhile, it has a chance that the file got updated and the updated timestamp saves in sincedb. The next iteration, only files with `last_modified`  > sincedb will be processed. Therefore, files updated between t1 and t2 could be left
2. Set the cutoff time. `last_modified` > cutoff (now - 3s) will be process in next iteration. 
Files with the same `last_modified` (t1) could be readable after  [summary](https://github.com/logstash-plugins/logstash-input-s3/blob/master/lib/logstash/inputs/s3.rb#L132) (t1) call. Due to the checking `last_modified`  > sincedb, the next iteration would not process files with `last_modified` (t1). By setting cutoff time, hopefully s3 return a repeatable file list.


Related Issue
https://github.com/logstash-plugins/logstash-input-s3/issues/221

The red CI is from Logstash 6.8 which has never been green since branching