### PR TITLE
Fix missing file because of cutoff time change

### DIFF
--- a/lib/logstash/inputs/s3.rb
+++ b/lib/logstash/inputs/s3.rb
@@ -130,6 +130,7 @@ class LogStash::Inputs::S3 < LogStash::Inputs::Base
   def list_new_files
     objects = []
     found = false
+    current_time = Time.now
     begin
       @s3bucket.objects(:prefix => @prefix).each do |log|
         found = true
@@ -140,7 +141,7 @@ class LogStash::Inputs::S3 < LogStash::Inputs::Base
           @logger.debug('Object Zero Length', :key => log.key)
         elsif !sincedb.newer?(log.last_modified)
           @logger.debug('Object Not Modified', :key => log.key)
-        elsif log.last_modified > (Time.now - CUTOFF_SECOND).utc # file modified within last two seconds will be processed in next cycle
+        elsif log.last_modified > (current_time - CUTOFF_SECOND).utc # file modified within last two seconds will be processed in next cycle
           @logger.debug('Object Modified After Cutoff Time', :key => log.key)
         elsif (log.storage_class == 'GLACIER' || log.storage_class == 'DEEP_ARCHIVE') && !file_restored?(log.object)
           @logger.debug('Object Archived to Glacier', :key => log.key)


### PR DESCRIPTION
cutoff time calculation part is using Time.now
But if file list to check is too many, sometimes Time.now will be change seconds. 
example)
previous loop : Time.now => 2021-04-06T20:13:59.996
current loop : Time.now => 2021-04-06T20:14:00.001
If two files have same modified second, first file is not process for next cycle.
The other is processed and update sincedb.
When next cycle, first file is not processed because first file's modified time is same sincedb.

If current_time will be getted before loop and use current_time  in loop , there will be no missing files.

Related Issue
#227 

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
