### PR TITLE
add ecs support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 3.7.0
  - Add ECS support. [#228](https://github.com/logstash-plugins/logstash-input-s3/pull/228)
+ - Fix missing file in cutoff time change. [#224](https://github.com/logstash-plugins/logstash-input-s3/pull/224)
 
 ## 3.6.0
  - Fixed unprocessed file with the same `last_modified` in ingestion. [#220](https://github.com/logstash-plugins/logstash-input-s3/pull/220)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 3.7.0
- - Add ECS support. [#221](https://github.com/logstash-plugins/logstash-input-s3/pull/221)
+ - Add ECS support. [#228](https://github.com/logstash-plugins/logstash-input-s3/pull/228)
 
 ## 3.6.0
  - Fixed unprocessed file with the same `last_modified` in ingestion. [#220](https://github.com/logstash-plugins/logstash-input-s3/pull/220)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.7.0
+ - Add ECS support. [#221](https://github.com/logstash-plugins/logstash-input-s3/pull/221)
+
 ## 3.6.0
  - Fixed unprocessed file with the same `last_modified` in ingestion. [#220](https://github.com/logstash-plugins/logstash-input-s3/pull/220)
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -31,6 +31,20 @@ Files ending in `.gz` are handled as gzip'ed files.
 
 Files that are archived to AWS Glacier will be skipped.
 
+==== Event Metadata and the Elastic Common Schema (ECS)
+This plugin adds cloudfront metadata to event.
+By default, the value is stored in the root level.
+When ECS is enabled, it is stored in the `@metadata`.
+
+Here’s how ECS compatibility mode affects output.
+[cols="<l,<l,e,<e"]
+|=======================================================================
+| disabled | v1 | Availability | Description
+
+| cloudfront_fields | [@metadata][s3][cloudfront][fields] | available when the file is a cloudfront metadata | columns name of metadata
+| cloudfront_version | [@metadata][s3][cloudfront][version] | available when the file is a cloudfront metadata | version of metadata
+|=======================================================================
+
 [id="plugins-{type}s-{plugin}-options"]
 ==== S3 Input Configuration Options
 
@@ -47,6 +61,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-backup_to_dir>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-bucket>> |<<string,string>>|Yes
 | <<plugins-{type}s-{plugin}-delete>> |<<boolean,boolean>>|No
+| <<plugins-{type}s-{plugin}-ecs_compatibility>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-endpoint>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-exclude_pattern>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-gzip_pattern>> |<<string,string>>|No
@@ -166,6 +181,17 @@ The name of the S3 bucket.
   * Default value is `false`
 
 Whether to delete processed files from the original bucket.
+
+[id="plugins-{type}s-{plugin}-ecs_compatibility"]
+===== `ecs_compatibility`
+
+* Value type is <<string,string>>
+* Supported values are:
+** `disabled`: does not use ECS-compatible field names
+** `v1`: uses fields that are compatible with Elastic Common Schema
+* Default value depends on which version of Logstash is running:
+** When Logstash provides a `pipeline.ecs_compatibility` setting, its value is used as the default
+** Otherwise, the default value is `disabled`.
 
 [id="plugins-{type}s-{plugin}-endpoint"]
 ===== `endpoint`

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -31,18 +31,19 @@ Files ending in `.gz` are handled as gzip'ed files.
 
 Files that are archived to AWS Glacier will be skipped.
 
+[id="plugins-{type}s-{plugin}-ecs_compatibility"]
 ==== Event Metadata and the Elastic Common Schema (ECS)
 This plugin adds cloudfront metadata to event.
-By default, the value is stored in the root level.
-When ECS is enabled, it is stored in the `@metadata`.
+When ECS compatibility is disabled, the value is stored in the root level.
+When ECS is enabled, the value is stored in the `@metadata` where it can be used by other plugins in your pipeline.
 
 Here’s how ECS compatibility mode affects output.
 [cols="<l,<l,e,<e"]
 |=======================================================================
-| disabled | v1 | Availability | Description
+| ECS disabled | ECS v1 | Availability | Description
 
-| cloudfront_fields | [@metadata][s3][cloudfront][fields] | available when the file is a cloudfront metadata | columns name of metadata
-| cloudfront_version | [@metadata][s3][cloudfront][version] | available when the file is a cloudfront metadata | version of metadata
+| cloudfront_fields | [@metadata][s3][cloudfront][fields] | available when the file is a CloudFront log | column names of log
+| cloudfront_version | [@metadata][s3][cloudfront][version] | available when the file is a CloudFront log | version of log
 |=======================================================================
 
 [id="plugins-{type}s-{plugin}-options"]
@@ -185,13 +186,14 @@ Whether to delete processed files from the original bucket.
 [id="plugins-{type}s-{plugin}-ecs_compatibility"]
 ===== `ecs_compatibility`
 
-* Value type is <<string,string>>
-* Supported values are:
-** `disabled`: does not use ECS-compatible field names
-** `v1`: uses fields that are compatible with Elastic Common Schema
-* Default value depends on which version of Logstash is running:
-** When Logstash provides a `pipeline.ecs_compatibility` setting, its value is used as the default
-** Otherwise, the default value is `disabled`.
+  * Value type is <<string,string>>
+  * Supported values are:
+  ** `disabled`: does not use ECS-compatible field names
+  ** `v1`: uses metadata fields that are compatible with Elastic Common Schema
+
+Controls this plugin's compatibility with the
+{ecs-ref}[Elastic Common Schema (ECS)].
+See <<plugins-{type}s-{plugin}-ecs_metadata,ECS mapping>> for detailed information.
 
 [id="plugins-{type}s-{plugin}-endpoint"]
 ===== `endpoint`

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -193,7 +193,7 @@ Whether to delete processed files from the original bucket.
 
 Controls this plugin's compatibility with the
 {ecs-ref}[Elastic Common Schema (ECS)].
-See <<plugins-{type}s-{plugin}-ecs_metadata,ECS mapping>> for detailed information.
+See <<plugins-{type}s-{plugin}-ecs_metadata>> for detailed information.
 
 [id="plugins-{type}s-{plugin}-endpoint"]
 ===== `endpoint`

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -31,7 +31,7 @@ Files ending in `.gz` are handled as gzip'ed files.
 
 Files that are archived to AWS Glacier will be skipped.
 
-[id="plugins-{type}s-{plugin}-ecs_compatibility"]
+[id="plugins-{type}s-{plugin}-ecs_metadata"]
 ==== Event Metadata and the Elastic Common Schema (ECS)
 This plugin adds cloudfront metadata to event.
 When ECS compatibility is disabled, the value is stored in the root level.

--- a/logstash-input-s3.gemspec
+++ b/logstash-input-s3.gemspec
@@ -27,4 +27,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'logstash-devutils'
   s.add_development_dependency "logstash-codec-json"
   s.add_development_dependency "logstash-codec-multiline"
+  s.add_runtime_dependency 'logstash-mixin-ecs_compatibility_support', '~>1.1'
 end

--- a/spec/inputs/s3_spec.rb
+++ b/spec/inputs/s3_spec.rb
@@ -499,7 +499,6 @@ describe LogStash::Inputs::S3 do
         ecs_compatibility_matrix(:disabled, :v1) do |ecs_select|
           before(:each) do
             allow_any_instance_of(described_class).to receive(:ecs_compatibility).and_return(ecs_compatibility)
-            # subject.register
           end
 
           it 'should extract metadata from cloudfront log' do


### PR DESCRIPTION
This PR adds ECS support and maps the following 
Legacy | ECS 
--- | ---
cloudfront_fields | [@metadata][s3][cloudfront][fields]
cloudfront_version | [@metadata][s3][cloudfront][version] 

Closed: https://github.com/logstash-plugins/logstash-input-s3/issues/196