### PR TITLE
Refactor: read sincedb time once per bucket listing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.8.2
+ - Refactor: read sincedb time once per bucket listing [#233](https://github.com/logstash-plugins/logstash-input-s3/pull/233)
+
 ## 3.8.1
  - Feat: cast true/false values for additional_settings [#232](https://github.com/logstash-plugins/logstash-input-s3/pull/232)
 

--- a/logstash-input-s3.gemspec
+++ b/logstash-input-s3.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-s3'
-  s.version         = '3.8.1'
+  s.version         = '3.8.2'
   s.licenses        = ['Apache-2.0']
   s.summary         = "Streams events from files in a S3 bucket"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/inputs/s3_spec.rb
+++ b/spec/inputs/s3_spec.rb
@@ -195,6 +195,7 @@ describe LogStash::Inputs::S3 do
       it 'should log that no files were found in the bucket' do
         plugin = LogStash::Inputs::S3.new(config)
         plugin.register
+        allow(plugin.logger).to receive(:info).with(/Using the provided sincedb_path/, anything)
         expect(plugin.logger).to receive(:info).with(/No files found/, anything)
         expect(plugin.list_new_files).to be_empty
       end


### PR DESCRIPTION
instead of stat/open/read/close-ing the file on every iteration ...

This is expected to improve performance in terms of File operations, which is esp. useful when using network storage.

The only (minor) downside is we read the `sincedb` eagerly, even if there are no objects to be processed.