### PR TITLE
Refactoring: update mixin-aws version to reuse shared code to manage `additional_settings`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.8.4
+ - Refactoring, reuse code to manage `additional_settings` from mixin-aws [#n](https://github.com/logstash-plugins/logstash-input-s3/pull/n)
+
 ## 3.8.3
  - Fix missing `metadata` and `type` of the last event [#223](https://github.com/logstash-plugins/logstash-input-s3/pull/223)
 

--- a/lib/logstash/inputs/s3.rb
+++ b/lib/logstash/inputs/s3.rb
@@ -357,25 +357,6 @@ class LogStash::Inputs::S3 < LogStash::Inputs::Base
     path
   end
 
-  def symbolized_settings
-    @symbolized_settings ||= symbolize_keys_and_cast_true_false(@additional_settings)
-  end
-
-  def symbolize_keys_and_cast_true_false(hash)
-    case hash
-    when Hash
-      symbolized = {}
-      hash.each { |key, value| symbolized[key.to_sym] = symbolize_keys_and_cast_true_false(value) }
-      symbolized
-    when 'true'
-      true
-    when 'false'
-      false
-    else
-      hash
-    end
-  end
-
   def ignore_filename?(filename)
     if @prefix == filename
       return true
@@ -441,8 +422,7 @@ class LogStash::Inputs::S3 < LogStash::Inputs::Base
   end
 
   def get_s3object
-    options = symbolized_settings.merge(aws_options_hash || {})
-    s3 = Aws::S3::Resource.new(options)
+    s3 = Aws::S3::Resource.new(aws_options_hash || {})
   end
 
   def file_restored?(object)

--- a/logstash-input-s3.gemspec
+++ b/logstash-input-s3.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-s3'
-  s.version         = '3.8.3'
+  s.version         = '3.8.4'
   s.licenses        = ['Apache-2.0']
   s.summary         = "Streams events from files in a S3 bucket"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 2.1.12", "<= 2.99"
-  s.add_runtime_dependency 'logstash-mixin-aws', '>= 4.3.0'
+  s.add_runtime_dependency 'logstash-mixin-aws', '>= 5.1.0'
   s.add_runtime_dependency 'stud', '~> 0.0.18'
  # s.add_runtime_dependency 'aws-sdk-resources', '>= 2.0.33'
   s.add_development_dependency 'logstash-devutils'


### PR DESCRIPTION
Refactoring, starting from  version `5.1.0` of mixin-aws it includes the shared logic for symbolization of `additional_settings`, this commit updates the dependency and fix the code to reuse that.
