### PR TITLE
Fix object timestamp logic

### DIFF
--- a/lib/logstash/inputs/s3.rb
+++ b/lib/logstash/inputs/s3.rb
@@ -375,19 +375,20 @@ class LogStash::Inputs::S3 < LogStash::Inputs::Base
 
   def process_log(queue, log)
     @logger.debug("Processing", :bucket => @bucket, :key => log.key)
-    object = @s3bucket.object(log.key)
+    object = @s3bucket.object(log.key).load
 
     filename = File.join(temporary_directory, File.basename(log.key))
     if download_remote_file(object, filename)
       if process_local_log(queue, filename, object)
-        if object.last_modified == log.last_modified
+        refreshed_object = @s3bucket.object(log.key)
+        if object.last_modified == refreshed_object.last_modified
           backup_to_bucket(object)
           backup_to_dir(filename)
           delete_file_from_bucket(object)
           FileUtils.remove_entry_secure(filename, true)
-          sincedb.write(log.last_modified)
+          sincedb.write(object.last_modified)
         else
-          @logger.info("#{log.key} is updated at #{object.last_modified} and will process in the next cycle")
+          @logger.info("#{log.key} is updated at #{refreshed_object.last_modified} and will process in the next cycle")
         end
       end
     else

--- a/lib/logstash/inputs/s3.rb
+++ b/lib/logstash/inputs/s3.rb
@@ -375,8 +375,9 @@ class LogStash::Inputs::S3 < LogStash::Inputs::Base
 
   def process_log(queue, log)
     @logger.debug("Processing", :bucket => @bucket, :key => log.key)
+    object = @s3bucket.object(log.key)
     # Eager-loads the object data so the last_modified field is populated right before the download
-    object = @s3bucket.object(log.key).load
+    object.load
 
     filename = File.join(temporary_directory, File.basename(log.key))
     if download_remote_file(object, filename)

--- a/spec/inputs/s3_spec.rb
+++ b/spec/inputs/s3_spec.rb
@@ -583,7 +583,7 @@ describe LogStash::Inputs::S3 do
       end
     end
 
-    context 's3 object updated after getting summary' do
+    context 's3 object updated during processing' do
       it 'should not update sincedb' do
         s3_summary = [
           double(:key => 'YESTERDAY', :last_modified => Time.now.round - day, :content_length => 5, :storage_class => 'STANDARD'),
@@ -592,6 +592,8 @@ describe LogStash::Inputs::S3 do
 
         s3_objects = [
           double(:key => 'YESTERDAY', :last_modified => Time.now.round - day, :content_length => 5, :storage_class => 'STANDARD'),
+          double(:key => 'YESTERDAY', :last_modified => Time.now.round - day, :content_length => 5, :storage_class => 'STANDARD'),
+          double(:key => 'TODAY', :last_modified => Time.now.round - (cutoff * 10), :content_length => 5, :storage_class => 'STANDARD'),
           double(:key => 'TODAY_UPDATED', :last_modified => Time.now.round, :content_length => 5, :storage_class => 'STANDARD')
         ]
 

--- a/spec/inputs/s3_spec.rb
+++ b/spec/inputs/s3_spec.rb
@@ -407,6 +407,7 @@ describe LogStash::Inputs::S3 do
       }
       allow_any_instance_of(Aws::S3::Bucket).to receive(:objects) { objects }
       allow_any_instance_of(Aws::S3::Bucket).to receive(:object).with(log.key) { log }
+      allow_any_instance_of(Aws::S3::Object).to receive(:load)
       expect(log).to receive(:get).with(instance_of(Hash)) do |arg|
         File.open(arg[:response_target], 'wb') { |s3file| s3file.write(data) }
       end
@@ -569,6 +570,7 @@ describe LogStash::Inputs::S3 do
 
         allow_any_instance_of(Aws::S3::Bucket).to receive(:objects) { s3_objects }
         allow_any_instance_of(Aws::S3::Bucket).to receive(:object).and_return(*s3_objects)
+        allow_any_instance_of(Aws::S3::Object).to receive(:load)
         expect(s3_plugin).to receive(:process_log).at_least(size).and_call_original
         expect(s3_plugin).to receive(:stop?).and_return(false).at_least(size)
         expect(s3_plugin).to receive(:download_remote_file).and_return(true).at_least(size)
@@ -601,6 +603,7 @@ describe LogStash::Inputs::S3 do
 
         allow_any_instance_of(Aws::S3::Bucket).to receive(:objects) { s3_summary }
         allow_any_instance_of(Aws::S3::Bucket).to receive(:object).and_return(*s3_objects)
+        allow_any_instance_of(Aws::S3::Object).to receive(:load)
         expect(s3_plugin).to receive(:process_log).at_least(size).and_call_original
         expect(s3_plugin).to receive(:stop?).and_return(false).at_least(size)
         expect(s3_plugin).to receive(:download_remote_file).and_return(true).at_least(size)

--- a/spec/inputs/s3_spec.rb
+++ b/spec/inputs/s3_spec.rb
@@ -32,6 +32,7 @@ describe LogStash::Inputs::S3 do
     FileUtils.mkdir_p(sincedb_path)
     Aws.config[:stub_responses] = true
     Thread.abort_on_exception = true
+    allow_any_instance_of(Aws::S3::Object).to receive(:load)
   end
 
   context "when interrupting the plugin" do
@@ -407,7 +408,6 @@ describe LogStash::Inputs::S3 do
       }
       allow_any_instance_of(Aws::S3::Bucket).to receive(:objects) { objects }
       allow_any_instance_of(Aws::S3::Bucket).to receive(:object).with(log.key) { log }
-      allow_any_instance_of(Aws::S3::Object).to receive(:load)
       expect(log).to receive(:get).with(instance_of(Hash)) do |arg|
         File.open(arg[:response_target], 'wb') { |s3file| s3file.write(data) }
       end
@@ -570,7 +570,6 @@ describe LogStash::Inputs::S3 do
 
         allow_any_instance_of(Aws::S3::Bucket).to receive(:objects) { s3_objects }
         allow_any_instance_of(Aws::S3::Bucket).to receive(:object).and_return(*s3_objects)
-        allow_any_instance_of(Aws::S3::Object).to receive(:load)
         expect(s3_plugin).to receive(:process_log).at_least(size).and_call_original
         expect(s3_plugin).to receive(:stop?).and_return(false).at_least(size)
         expect(s3_plugin).to receive(:download_remote_file).and_return(true).at_least(size)
@@ -603,7 +602,6 @@ describe LogStash::Inputs::S3 do
 
         allow_any_instance_of(Aws::S3::Bucket).to receive(:objects) { s3_summary }
         allow_any_instance_of(Aws::S3::Bucket).to receive(:object).and_return(*s3_objects)
-        allow_any_instance_of(Aws::S3::Object).to receive(:load)
         expect(s3_plugin).to receive(:process_log).at_least(size).and_call_original
         expect(s3_plugin).to receive(:stop?).and_return(false).at_least(size)
         expect(s3_plugin).to receive(:download_remote_file).and_return(true).at_least(size)


### PR DESCRIPTION
This should make the s3 input compatible with more S3 compatible backends since the timestamps are taken from the same call.
It also changes the logic to something I thought makes more sense.
It shouldn't really matter if a file has changed since listing, just if it has changed during downloading/processing.
If it had just changed during listing but before the download, the exact same file would be processed twice.
