### PR TITLE
fix: issue with timestamp comparison

### DIFF
--- a/lib/logstash/inputs/s3.rb
+++ b/lib/logstash/inputs/s3.rb
@@ -148,7 +148,7 @@ class LogStash::Inputs::S3 < LogStash::Inputs::Base
           @logger.debug('Ignoring', :key => log.key)
         elsif log.content_length <= 0
           @logger.debug('Object Zero Length', :key => log.key)
-        elsif log.last_modified <= sincedb_time
+        elsif log.last_modified.to_i <= sincedb_time.to_i
           @logger.debug('Object Not Modified', :key => log.key)
         elsif log.last_modified > (current_time - CUTOFF_SECOND).utc # file modified within last two seconds will be processed in next cycle
           @logger.debug('Object Modified After Cutoff Time', :key => log.key)
@@ -380,7 +380,7 @@ class LogStash::Inputs::S3 < LogStash::Inputs::Base
     filename = File.join(temporary_directory, File.basename(log.key))
     if download_remote_file(object, filename)
       if process_local_log(queue, filename, object)
-        if object.last_modified == log.last_modified
+        if object.last_modified.to_i == log.last_modified.to_i
           backup_to_bucket(object)
           backup_to_dir(filename)
           delete_file_from_bucket(object)


### PR DESCRIPTION
Problem:
The logstash-input-s3 plugin has a known issue regarding object timestamp logic, causing problems when using S3-compatible storage solutions other than AWS S3. This issue has been discussed in the following GitHub pull request and issue:
Pull Request: [Fix object timestamp logic](https://github.com/logstash-plugins/logstash-input-s3/pull/243)
Issue: [sincedb file not created, files from bucket not deleted](https://github.com/logstash-plugins/logstash-input-s3/issues/236)

Proposed Solution:
To address both problems, a suggested fix has been proposed in the pull request. This fix aims to make the logstash-input-s3 plugin compatible with more S3-compatible backends by improving the timestamp handling logic.

Context:
It’s important to note that the logstash-input-s3 plugin was originally designed to work only with AWS S3 and does not officially support other S3-compatible storage solutions. However, implementing the proposed fix would make the plugin suitable for a significant number of alternative S3-compatible solutions, eliminating the need for unsupported forks.

Microseconds Comparison:
The core issue lies in the comparison of timestamps with microseconds precision, which causes two main problems: the sincedb file not being created and duplicated reads of files from the S3 bucket. This issue is well-explained in the blog post titled “Time comparison in Ruby” by Railsware, which discusses the challenges and confusion associated with time comparison in Ruby. ([Link](https://railsware.com/blog/time-comparison-in-ruby/))

Root Cause Uncertainty:
It’s worth noting that the root cause of the microseconds difference between file list timestamps in buckets and the last sincedb writes is still uncertain. This issue does not occur when using the logstash-input-s3 plugin with AWS S3, only on other S3 compatible backends.

Issue in question is present in Cloudfare R2 and DigitalOcean Spaces, and the fix has been tested with them as well:
Cloudflare R2: A S3-compatible storage solution provided by Cloudflare. ([Link](https://www.cloudflare.com/en-gb/lp/pg-r2/))
DigitalOcean Spaces: A S3-compatible object storage service offered by DigitalOcean. ([Link](https://www.digitalocean.com/products/spaces))