### PR TITLE
fix: ensure consistent timestamp comparison in S3 input

### DIFF
--- a/lib/logstash/inputs/s3.rb
+++ b/lib/logstash/inputs/s3.rb
@@ -380,7 +380,7 @@ class LogStash::Inputs::S3 < LogStash::Inputs::Base
     filename = File.join(temporary_directory, File.basename(log.key))
     if download_remote_file(object, filename)
       if process_local_log(queue, filename, object)
-        if object.last_modified == log.last_modified
+        if Time.parse(object.last_modified.to_s) == Time.parse(log.last_modified.to_s)
           backup_to_bucket(object)
           backup_to_dir(filename)
           delete_file_from_bucket(object)


### PR DESCRIPTION
- Normalize `last_modified` timestamps by parsing with `Time.parse` for accurate comparison.
- Ensures consistent comparison between object metadata and log entries in S3 input.
- MinIO provided different formats for `last_modified` timestamps (e.g., "UTC" vs "+0000"), causing mismatches during comparison.